### PR TITLE
Added a prefix to the name of the tempfile files

### DIFF
--- a/renderers/Appleseed.py
+++ b/renderers/Appleseed.py
@@ -95,7 +95,7 @@ def writeObject(viewobj,mesh,color,alpha):
 
     # write the mesh as an obj tempfile
 
-    meshfile = tempfile.mkstemp(suffix=".obj")[1]
+    meshfile = tempfile.mkstemp(suffix=".obj", prefix="_")[1]
     objfile = os.path.splitext(os.path.basename(meshfile))[0]
     mesh.write(meshfile)
 


### PR DESCRIPTION
Added a prefix "_" to temporary files as without it, the value of the variable "meshfile" when outputting to * .appleseed is written with a tab character as in the example below:
`<parameter name="filename" value="C:\Users\andy\AppData\Local\Temp\FreeCAD PortableTemp    mp8css_og7.obj" />`
but should be:
`<parameter name="filename" value="C:\Users\andy\AppData\Local\Temp\FreeCAD PortableTemp\tmp8css_og7.obj" />`