### PR TITLE
Renderer improvements

### DIFF
--- a/Render.py
+++ b/Render.py
@@ -231,7 +231,7 @@ class Project:
             obj.addProperty("App::PropertyFile","OutputImage","Render", QT_TRANSLATE_NOOP("App::Property","The image saved by this render"))
         if not "OpenAfterRender" in obj.PropertiesList:
             obj.addProperty("App::PropertyBool","OpenAfterRender","Render", QT_TRANSLATE_NOOP("App::Property","If true, the rendered image is opened in FreeCAD after the rendering is finished"))
-            obj.GroundPlane = False
+            obj.OpenAfterRender = False
         obj.setEditorMode("PageResult",2)
         obj.setEditorMode("Camera",2)
 

--- a/Render.py
+++ b/Render.py
@@ -59,9 +59,15 @@ def doRender(project, external=True):
         ImageGui.open(img)
 
 class RenderMaterial:
+    '''
+    Attributes:
+        uvcoordinates: A list of tuples where each tuple defines the uv coordinates for the vertex at this position'''
     def __init__(self, color, alpha):
         self.color = color
         self.alpha = alpha
+        self.imageTextureFile = None
+        self.uvcoordinates = None
+        self.uvindices = None
 
 class RenderProjectCommand:
 
@@ -371,15 +377,15 @@ class Project:
             
         return RenderMaterial(color, alpha)
     
-    def calculateMaterialData(self, obj, view):
+    def calculateMaterialData(self, obj, view, mesh):
         material = self.calculateDefaultMaterialData(view)
 
         if hasattr(obj, 'MaterialPipeline') and obj.MaterialPipeline is not None:
             for materialEnhancer in obj.MaterialPipeline:
                 if hasattr(materialEnhancer, 'enhanceMaterial'):
-                    materialEnhancer.enhanceMaterial(material, view)
+                    materialEnhancer.enhanceMaterial(material, view, mesh)
                 elif hasattr(materialEnhancer, 'Proxy') and hasattr(materialEnhancer.Proxy, 'enhanceMaterial'):
-                    materialEnhancer.Proxy.enhanceMaterial(material, view)
+                    materialEnhancer.Proxy.enhanceMaterial(material, view, mesh)
 
         return material
 
@@ -394,8 +400,6 @@ class Project:
                 FreeCAD.Console.PrintError(translate("Render","Error importing renderer")+" "+str(obj.Renderer))
                 return ""
             else:
-                material = self.calculateMaterialData(obj, view)
-
                 # get mesh
                 import Draft
                 import Part
@@ -416,6 +420,8 @@ class Project:
                     mesh = view.Source.Mesh
                 if not mesh:
                     return ""
+
+                material = self.calculateMaterialData(obj, view, mesh)
 
                 return renderer.writeObject(view,mesh,material)
 

--- a/Render.py
+++ b/Render.py
@@ -51,7 +51,12 @@ else:
 def QT_TRANSLATE_NOOP(scope, text):
     return text
 
-
+def doRender(project, external=True):
+    img = project.Proxy.render(project,external)
+    
+    if img and hasattr(project,"OpenAfterRender") and project.OpenAfterRender:
+        import ImageGui
+        ImageGui.open(img)
 
 
 class RenderProjectCommand:
@@ -149,11 +154,7 @@ class RenderCommand:
         if not project:
             FreeCAD.Console.PrintError(translate("Render","Unable to find a valid project in selection or document"))
             return
-        img = project.Proxy.render(project)
-        if img and hasattr(project,"OpenAfterRender") and project.OpenAfterRender:
-            import ImageGui
-            ImageGui.open(img)
-
+        doRender(project)
 
 class RenderExternalCommand:
 
@@ -184,12 +185,7 @@ class RenderExternalCommand:
         if not project:
             FreeCAD.Console.PrintError(translate("Render","Unable to find a valid project in selection or document"))
             return
-        img = project.Proxy.render(project,external=True)
-        if img and hasattr(project,"OpenAfterRender") and project.OpenAfterRender:
-            import ImageGui
-            ImageGui.open(img)
-
-
+        doRender(project, external=True)
 
 class Project:
 
@@ -550,7 +546,7 @@ class ViewProviderProject:
 
     def render(self):
         if hasattr(self,"Object"):
-            self.Object.Proxy.render(self.Object)
+            doRender(self.Object)
 
     def claimChildren(self):
         if hasattr(self,"Object"):

--- a/renderers/Appleseed.py
+++ b/renderers/Appleseed.py
@@ -192,7 +192,7 @@ def render(project,prefix,external,output,width,height):
         return
     if args:
         args += " "
-    os.system(prefix+rpath+" "+args+project.PageResult)
+    os.system('"' + prefix+rpath+'" '+args+project.PageResult)
     return
 
 

--- a/renderers/Appleseed.py
+++ b/renderers/Appleseed.py
@@ -31,7 +31,7 @@ from __future__ import print_function
 # A render engine module must contain the following functions:
 #
 #    writeCamera(por,rot,up,target): returns a string containing an openInventor camera string in renderer format
-#    writeObject(view,mesh,color,alpha): returns a string containing a RaytracingView object in renderer format
+#    writeObject(view,mesh,material): returns a string containing a RaytracingView object in renderer format
 #    render(project,prefix,external,output,width,height): renders the given project, external means
 #                                                         if the user wishes to open the render file
 #                                                         in an external application/editor or not. If this
@@ -75,13 +75,17 @@ def writeCamera(pos,rot,up,target):
     return cam
 
 
-def writeObject(viewobj,mesh,color,alpha):
+def writeObject(viewobj,mesh,color,material):
 
     # This is where you write your object/view in the format of your
     # renderer. "obj" is the real 3D object handled by this project, not
     # the project itself. This is your only opportunity
     # to write all the data needed by your object (geometry, materials, etc)
     # so make sure you include everything that is needed
+    #
+    # material is a object with the folowing properties
+    #  - color: the color for the object
+    #  - alpha: the alpha value for the object
 
     objname = viewobj.Name
     colorname = objname + "_color"
@@ -90,8 +94,8 @@ def writeObject(viewobj,mesh,color,alpha):
 
     # format color and alpha
 
-    color = str(color[0])+" "+str(color[1])+" "+str(color[2])
-    alpha = str(alpha)
+    color = str(material.color[0])+" "+str(material.color[1])+" "+str(material.color[2])
+    alpha = str(material.alpha)
 
     # write the mesh as an obj tempfile
 

--- a/renderers/Cycles.py
+++ b/renderers/Cycles.py
@@ -139,7 +139,7 @@ def render(project,prefix,external,output,width,height):
         return
     args += " --width "+str(width)
     args += " --height "+str(height)
-    os.system(prefix+rpath+" "+args+" "+project.PageResult)
+    os.system('"' + prefix+rpath+'" '+args+" "+project.PageResult)
 
     return output
 

--- a/renderers/Cycles.py
+++ b/renderers/Cycles.py
@@ -31,7 +31,7 @@ from __future__ import print_function
 # A render engine module must contain the following functions:
 #
 #    writeCamera(por,rot,up,target): returns a string containing an openInventor camera string in renderer format
-#    writeObject(view,mesh,color,alpha): returns a string containing a RaytracingView object in renderer format
+#    writeObject(view,mesh,material): returns a string containing a RaytracingView object in renderer format
 #    render(project,prefix,external,output,width,height): renders the given project, external means 
 #                                                         if the user wishes to open the render file 
 #                                                         in an external application/editor or not. If this
@@ -68,13 +68,17 @@ def writeCamera(pos,rot,up,target):
     return cam
 
 
-def writeObject(viewobj,mesh,color,alpha):
+def writeObject(viewobj,mesh,material):
 
     # This is where you write your object/view in the format of your
     # renderer. "obj" is the real 3D object handled by this project, not
     # the project itself. This is your only opportunity
     # to write all the data needed by your object (geometry, materials, etc)
     # so make sure you include everything that is needed
+    #
+    # material is a object with the folowing properties
+    #  - color: the color for the object
+    #  - alpha: the alpha value for the object
 
     bsdfname = viewobj.Name + "_bsdf"
     matname = viewobj.Name + "_mat"
@@ -83,7 +87,8 @@ def writeObject(viewobj,mesh,color,alpha):
 
     # format color data
 
-    color = str(color[0])+", "+str(color[1])+", "+str(color[2])
+    color = str(material.color[0])+", "+str(material.color[1])+", "+str(material.color[2])
+    alpha = material.alpha
     
     # write shader
     

--- a/renderers/Luxrender.py
+++ b/renderers/Luxrender.py
@@ -30,7 +30,7 @@
 # A render engine module must contain the following functions:
 #
 #    writeCamera(por,rot,up,target): returns a string containing an openInventor camera string in renderer format
-#    writeObject(view,mesh,color,alpha): returns a string containing a RaytracingView object in renderer format
+#    writeObject(view,mesh,material): returns a string containing a RaytracingView object in renderer format
 #    render(project,prefix,external,output,width,height): renders the given project, external means
 #                                                         if the user wishes to open the render file
 #                                                         in an external application/editor or not. If this
@@ -67,20 +67,25 @@ def writeCamera(pos,rot,up,target):
     return cam
 
 
-def writeObject(viewobj,mesh,color,alpha):
+def writeObject(viewobj,mesh,material):
 
     # This is where you write your object/view in the format of your
     # renderer. "obj" is the real 3D object handled by this project, not
     # the project itself. This is your only opportunity
     # to write all the data needed by your object (geometry, materials, etc)
     # so make sure you include everything that is needed
+    #
+    # material is a object with the folowing properties
+    #  - color: the color for the object
+    #  - alpha: the alpha value for the object
 
 
     objdef = ""
     objname = viewobj.Name
 
     # format color
-    color = str(color[0])+" "+str(color[1])+" "+str(color[2])
+    color = str(material.color[0])+" "+str(material.color[1])+" "+str(material.color[2])
+    alpha = material.alpha
 
     P = ""
     N = ""

--- a/renderers/Luxrender.py
+++ b/renderers/Luxrender.py
@@ -156,7 +156,7 @@ def render(project,prefix,external,output,width,height):
     if args:
         args += " "
     FreeCAD.Console.PrintMessage(prefix+rpath+" "+args+project.PageResult+"\n")
-    os.system(prefix+rpath+" "+args+project.PageResult)
+    os.system('"' + prefix+rpath+'" '+args+project.PageResult)
     return
 
 

--- a/renderers/Povray.py
+++ b/renderers/Povray.py
@@ -88,35 +88,16 @@ def writeObject(viewobj,mesh,material):
 
     objname = viewobj.Name
     
-    color = str(material.color[0])+","+str(material.color[1])+","+str(material.color[2])
-
     objdef = ""
     objdef += "#declare " + objname + " = mesh2{\n"
-    objdef += "  vertex_vectors {\n"
-    objdef += "    " + str(len(mesh.Topology[0])) + ",\n"
-    for p in mesh.Topology[0]:
-        objdef += "    <" + str(p.x) + "," + str(p.z) + "," + str(p.y) + ">,\n"
-    objdef += "  }\n"
-    objdef += "  normal_vectors {\n"
-    objdef += "    " + str(len(mesh.Topology[0])) + ",\n"
-    for p in mesh.getPointNormals():
-        objdef += "    <" + str(p.x) + "," + str(p.z) + "," + str(p.y) + ">,\n"
-    objdef += "  }\n"
-    objdef += "  face_indices {\n"
-    objdef += "    " + str(len(mesh.Topology[1])) + ",\n"
-    for t in mesh.Topology[1]:
-        objdef += "    <" + str(t[0]) + "," + str(t[1]) + "," + str(t[2]) + ">,\n"
-    objdef += "  }\n"
+    objdef += createVertexVectors(mesh)
+    objdef += createNormalVectors(mesh)
+    objdef += createFaceIndices(mesh)
     objdef += "}\n"
     
     objdef += "// instance to render\n"
     objdef += "object {" + objname + "\n"
-    objdef += "  texture {\n"
-    objdef += "    pigment {\n"
-    objdef += "      color rgb <" + color + ">\n"
-    objdef += "    }\n"
-    objdef += "    finish {StdFinish }\n"
-    objdef += "  }\n"
+    objdef += createTexture(material)
     objdef += "}\n"
 
     return objdef
@@ -155,3 +136,43 @@ def render(project,prefix,external,output,width,height):
     return imgname
 
 
+# helper methods
+
+def createVertexVectors(mesh):
+    vertexvectors = "  vertex_vectors {\n"
+    vertexvectors += "    " + str(len(mesh.Topology[0])) + ",\n"
+    for p in mesh.Topology[0]:
+        vertexvectors += "    <" + str(p.x) + "," + str(p.z) + "," + str(p.y) + ">,\n"
+    vertexvectors += "  }\n"
+
+    return vertexvectors
+
+def createNormalVectors(mesh):
+    normalvectors = "  normal_vectors {\n"
+    normalvectors += "    " + str(len(mesh.Topology[0])) + ",\n"
+    for p in mesh.getPointNormals():
+        normalvectors += "    <" + str(p.x) + "," + str(p.z) + "," + str(p.y) + ">,\n"
+    normalvectors += "  }\n"
+
+    return normalvectors
+
+def createFaceIndices(mesh):
+    faceindices = "  face_indices {\n"
+    faceindices += "    " + str(len(mesh.Topology[1])) + ",\n"
+    for t in mesh.Topology[1]:
+        faceindices += "    <" + str(t[0]) + "," + str(t[1]) + "," + str(t[2]) + ">,\n"
+    faceindices += "  }\n"
+
+    return faceindices
+
+def createTexture(material):
+    color = str(material.color[0])+","+str(material.color[1])+","+str(material.color[2])
+
+    texture = "  texture {\n"
+    texture += "    pigment {\n"
+    texture += "      color rgb <" + color + ">\n"
+    texture += "    }\n"
+    texture += "    finish {StdFinish }\n"
+    texture += "  }\n"
+
+    return texture

--- a/renderers/Povray.py
+++ b/renderers/Povray.py
@@ -144,7 +144,8 @@ def render(project,prefix,external,output,width,height):
     else:
         args = args + "+H"+str(height)+" "
     import os
-    os.system(prefix+rpath+" "+args+project.PageResult)
+
+    os.system('"' + prefix+rpath+'" '+args+project.PageResult)
     imgname = os.path.splitext(project.PageResult)[0]+".png"
     
     return imgname

--- a/renderers/Povray.py
+++ b/renderers/Povray.py
@@ -30,7 +30,7 @@
 # A render engine module must contain the following functions:
 #
 #    writeCamera(por,rot,up,target): returns a string containing an openInventor camera string in renderer format
-#    writeObject(view,mesh,color,alpha): returns a string containing a RaytracingView object in renderer format
+#    writeObject(view,mesh,material): returns a string containing a RaytracingView object in renderer format
 #    render(project,prefix,external,output,width,height): renders the given project, external means 
 #                                                         if the user wishes to open the render file 
 #                                                         in an external application/editor or not. If this
@@ -74,17 +74,21 @@ def writeCamera(pos,rot,up,target):
     return cam
 
 
-def writeObject(viewobj,mesh,color,alpha):
+def writeObject(viewobj,mesh,material):
 
     # This is where you write your object/view in the format of your
     # renderer. "obj" is the real 3D object handled by this project, not
     # the project itself. This is your only opportunity
     # to write all the data needed by your object (geometry, materials, etc)
     # so make sure you include everything that is needed
+    # 
+    # material is a object with the folowing properties
+    #  - color: the color for the object
+    #  - alpha: the alpha value for the object
 
     objname = viewobj.Name
     
-    color = str(color[0])+","+str(color[1])+","+str(color[2])
+    color = str(material.color[0])+","+str(material.color[1])+","+str(material.color[2])
 
     objdef = ""
     objdef += "#declare " + objname + " = mesh2{\n"


### PR DESCRIPTION
I did some work and refactored some things in the renderer in preparation to get textures from the ArchTexture Workbench to be picked up for rendering.


**Important**: The pull request is mainly a basis for discussion. It might be merged as it is and should work. But before merging have a look at https://github.com/justnope/FreeCAD-render/tree/cycles There are also similar refactorings going on. I don't know how far the implementation is right now.

## Commit Description
 
### Fix problems with spaces in path
At least for me on windows, where the path to the renderer executable has a space in it, the os.system call did not work. Wrapping the executable in quotes fixes the problem. Did not test this on other systems but I think this should work everywhere.

###  Harmonize render handling
When rendering via the context menu the logic was different than on rendering with the render command. I added a doRender method that is called in every place.

###  Prepare for additional material properties
This commit adds a RenderMaterial class that holds all material related properties for a object. And the renderers are refactored to get the material passed in instead of color and alpha individually. This makes it easier later on to add more properties to the material and implement this in only a couple of renderers without breaking compatibility to other renderers.

This commit might break compatility with already existing scripts. But as the workbench is pretty new, and the migration is simply to use "renderer.writeObject(..., RenderMaterial(color, alpha)" instead of "renderer.writeObject(..., color, alpha)" I think the refactoring should not cause major problems.

### Fix wrong property assignment
GroundPlane was overriden here instead of setting the initial value for OpenAfterRender. Looks like a copy paste mistake.

### Prepare POV-Ray renderer for image textures
This commit simply extracts some code into helper methods. This should make the writeObject method more readable when we later add more conditional stuff like textures.

### Add a material pipeline to the renderer 
The material pipeline is a App::PropertyLinkList for the renderer. One can pass a list of DocumentObjects in that have a "enhanceMaterial" method or a Proxy with an "enhanceMaterial" method. This are called in order with the RenderMaterial for a object and can add or override properties of the material.

I want to implement such a method in the ArchTexture workbench. This makes it possible for a user to pass the TextureConfig into the material pipeline of a Render project and the textures that are displayed in FreeCAD will also be available for rendering.

I decided to create a Material pipeline this way, because so the two Workbenches do not need to depend on each other. This would be a pretty bad thing I think, when ArchTexture must know about Render Workbench or the other way.

It also adds great flexibility for the user. Lets say someone wants to have random colors for the objects. Siply implement a FeaturePython object with a "enhanceMaterial" property and do whatever you want to do to create a material color.

And when some time the Textures are a core feature of FreeCAD, it is easy to switch to the core and still support the ArchTextures for compatibility.

## Work in progress
I have planned to do the following with some future commits.
### Add textures from ArchTexture workbench
I want to implement the enhanceMaterial method in the ArchTexture Workbench so that a user can add the TextureConfig to the material pipeline and the textures they see in FreeCAD are picked up for rendering too.