### PR TITLE
[Lux/Render] Make Luxrender call non-blocking

### DIFF
--- a/renderers/Luxrender.py
+++ b/renderers/Luxrender.py
@@ -48,6 +48,8 @@ import math
 import os
 import re
 import tempfile
+import shlex
+import subprocess
 
 
 def writeCamera(pos,rot,up,target):
@@ -155,8 +157,12 @@ def render(project,prefix,external,output,width,height):
         return
     if args:
         args += " "
-    FreeCAD.Console.PrintMessage(prefix+rpath+" "+args+project.PageResult+"\n")
-    os.system(prefix+rpath+" "+args+project.PageResult)
+
+    # Call Luxrender
+    cmd = prefix+rpath+" "+args+project.PageResult+"\n"
+    FreeCAD.Console.PrintMessage(cmd)
+    try:
+        p = subprocess.Popen(shlex.split(cmd))
+    except OSError as e:
+        FreeCAD.Console.PrintError("Luxrender call failed: '" + e.strerror +"'\n")
     return
-
-


### PR DESCRIPTION
Make Luxrender spawn in a distinct subprocess, so that FreeCAD remains
responsive during rendering.
By the way, it suppresses 'os.system' use, which seems deprecated in favor
of 'subprocess': https://docs.python.org/3.7/library/os.html#os.system