### PR TITLE
Close handle returned by tempfile.mkstemp

### DIFF
--- a/Render.py
+++ b/Render.py
@@ -465,12 +465,13 @@ class Project:
                 template = re.sub("(.*RaytracingContent.*)",cam+"\n"+renderobjs,template)
 
             # save page result
-            fp = tempfile.mkstemp(prefix=obj.Name,suffix=os.path.splitext(obj.Template)[-1])[1]
+            fh, fp = tempfile.mkstemp(prefix=obj.Name,suffix=os.path.splitext(obj.Template)[-1])
             f = open(fp,"w")
             if sys.version_info.major < 3:
                 template = template.encode("utf8")
             f.write(template)
             f.close()
+            os.close(fh)
             obj.PageResult = fp
             os.remove(fp)
 

--- a/renderers/Appleseed.py
+++ b/renderers/Appleseed.py
@@ -95,7 +95,8 @@ def writeObject(viewobj,mesh,color,alpha):
 
     # write the mesh as an obj tempfile
 
-    meshfile = tempfile.mkstemp(suffix=".obj", prefix="_")[1]
+    fd, meshfile = tempfile.mkstemp(suffix=".obj", prefix="_")
+    os.close(fd)
     objfile = os.path.splitext(os.path.basename(meshfile))[0]
     mesh.write(meshfile)
 
@@ -169,7 +170,8 @@ def render(project,prefix,external,output,width,height):
     res = re.findall("<parameter name=\"resolution.*?\/>",t)
     if res:
         t = t.replace(res[0],"<parameter name=\"resolution\" value=\""+str(width)+" "+str(height)+"\" />")
-        fp = tempfile.mkstemp(prefix=project.Name,suffix=os.path.splitext(project.Template)[-1])[1]
+        fd, fp = tempfile.mkstemp(prefix=project.Name,suffix=os.path.splitext(project.Template)[-1])
+        os.close(fd)
         f = open(fp,"w")
         f.write(t)
         f.close()

--- a/renderers/Luxrender.py
+++ b/renderers/Luxrender.py
@@ -137,7 +137,8 @@ def render(project,prefix,external,output,width,height):
     if res:
         t = re.sub("\"integer yresolution\".*?\[.*?\]","\"integer yresolution\" ["+str(height)+"]",t)
     if res:
-        fp = tempfile.mkstemp(prefix=project.Name,suffix=os.path.splitext(project.Template)[-1])[1]
+        fd, fp = tempfile.mkstemp(prefix=project.Name,suffix=os.path.splitext(project.Template)[-1])
+        os.close(fd)
         f = open(fp,"w")
         f.write(t)
         f.close()


### PR DESCRIPTION
Windows prevents you from deleting a file unless all handles are closed.
This resulted in an exception