### PR TITLE
Pointlights

### DIFF
--- a/Render.py
+++ b/Render.py
@@ -359,7 +359,7 @@ class Project:
         except AttributeError:
             FreeCAD.Console.PrintError(translate("Render","Cannot render Point Light: Missing location and/or color attributes"))
             return ""
-        power = getattr(view.Source,"RenderingPower",60) # For backward compatibility, we accept missing power...
+        power = getattr(view.Source,"RenderingPower",60) # We accept missing power...
 
         # send everything to renderer module
         return renderer.writePointLight(view,location,color,power)

--- a/renderers/Appleseed.py
+++ b/renderers/Appleseed.py
@@ -162,6 +162,13 @@ def writeObject(viewobj,mesh,color,alpha):
     return objdef
 
 
+def writePointLight(view,location,color,power):
+    # this is where you write the renderer-specific code
+    # to export the point light in the renderer format
+
+    # TODO
+    return ""
+
 def render(project,prefix,external,output,width,height):
 
     # here you trigger a render by firing the renderer

--- a/renderers/Cycles.py
+++ b/renderers/Cycles.py
@@ -119,6 +119,13 @@ def writeObject(viewobj,mesh,color,alpha):
     return objdef
 
 
+def writePointLight(view,location,color,power):
+    # this is where you write the renderer-specific code
+    # to export the point light in the renderer format
+
+    # TODO
+    return ""
+
 def render(project,prefix,external,output,width,height):
 
     # here you trigger a render by firing the renderer

--- a/renderers/Luxrender.py
+++ b/renderers/Luxrender.py
@@ -120,6 +120,13 @@ def writeObject(viewobj,mesh,color,alpha):
     return objdef
 
 
+def writePointLight(view,location,color,power):
+    # this is where you write the renderer-specific code
+    # to export the point light in the renderer format
+
+    # TODO
+    return ""
+
 def render(project,prefix,external,output,width,height):
 
     # here you trigger a render by firing the renderer

--- a/renderers/Povray.py
+++ b/renderers/Povray.py
@@ -117,6 +117,19 @@ def writeObject(viewobj,mesh,color,alpha):
 
     return objdef
 
+def writePointLight(view,location,color,power):
+    # this is where you write the renderer-specific code
+    # to export the point light in the renderer format
+
+
+    # Note: power is of no use for pov-ray
+    objdef = []
+    objdef += "\nlight_source {"
+    objdef += "<{},{},{}> ".format(*location)
+    objdef += "color rgb<{},{},{}>".format(*color)
+    objdef += "}\n\n"
+
+    return ''.join(objdef)
 
 def render(project,prefix,external,output,width,height):
 

--- a/renderers/Povray.py
+++ b/renderers/Povray.py
@@ -43,6 +43,11 @@
 #    An icon under the name Renderer.svg (where Renderer is the name of your Renderer
 
 
+# POV-Ray specific:
+# Tip: please note that POV-Ray coordinate system appears to be different from FreeCAD's
+# one (z and y permuted)
+# See here: https://www.povray.org/documentation/3.7.0/t2_2.html#t2_2_1_1
+
 import FreeCAD
 import math
 import re
@@ -83,7 +88,7 @@ def writeObject(viewobj,mesh,color,alpha):
     # so make sure you include everything that is needed
 
     objname = viewobj.Name
-    
+
     color = str(color[0])+","+str(color[1])+","+str(color[2])
 
     objdef = ""
@@ -125,7 +130,7 @@ def writePointLight(view,location,color,power):
     # Note: power is of no use for pov-ray
     objdef = []
     objdef += "\nlight_source {"
-    objdef += "<{},{},{}> ".format(*location)
+    objdef += "<{},{},{}> ".format(location.x,location.z,location.y)
     objdef += "color rgb<{},{},{}>".format(*color)
     objdef += "}\n\n"
 


### PR DESCRIPTION
This PR allows user to add Point Lights in a rendering scene, to be processed by the renderer.
For now, it's developed only for POV-Ray, but it will be extended to other renderers in a next step.

Usage:
Add a Point Light with Arch Texture workbench (set its color, position...)
Import the Point Light in your rendering project, via Render workbench
Render!


By the way, I also did some refactoring in the render.py module. In particular, I modified the code so that the renderer module is not imported when exporting each object, but only once when exporting the complete project (and I also added comments in the code).

