### PR TITLE
Add a Camera object

### DIFF
--- a/Camera.py
+++ b/Camera.py
@@ -1,0 +1,428 @@
+#***************************************************************************
+#*                                                                         *
+#*   Copyright (c) 2020 Howetuft <howetuft@gmail.com>                      *
+#*                                                                         *
+#*   This program is free software; you can redistribute it and/or modify  *
+#*   it under the terms of the GNU Lesser General Public License (LGPL)    *
+#*   as published by the Free Software Foundation; either version 2 of     *
+#*   the License, or (at your option) any later version.                   *
+#*   for detail see the LICENCE text file.                                 *
+#*                                                                         *
+#*   This program is distributed in the hope that it will be useful,       *
+#*   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+#*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+#*   GNU Library General Public License for more details.                  *
+#*                                                                         *
+#*   You should have received a copy of the GNU Library General Public     *
+#*   License along with this program; if not, write to the Free Software   *
+#*   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+#*   USA                                                                   *
+#*                                                                         *
+#***************************************************************************
+
+"""This module implements a Camera object, which allows to take a snapshot
+of Coin Camera settings and use them later for rendering"""
+
+from collections import namedtuple
+from math import degrees, radians
+import shlex
+
+from PySide2.QtWidgets import QAction
+from PySide2.QtCore import QT_TRANSLATE_NOOP, QObject, SIGNAL
+from pivy import coin
+
+import FreeCAD
+import FreeCADGui
+import Part
+
+# ===========================================================================
+
+def createCamera():
+    """Create a Camera object in active document"""
+
+    fpo = FreeCAD.ActiveDocument.addObject("Part::FeaturePython", "Camera")
+    Camera(fpo)
+    viewp = ViewProviderCamera(fpo.ViewObject)
+    if FreeCAD.GuiUp:
+        viewp.setCameraFromGui()
+    FreeCAD.ActiveDocument.recompute()
+    return fpo
+
+# ===========================================================================
+
+class Camera:
+
+    """A camera for rendering.
+
+This object allows to record camera settings from the Coin camera, and to reuse them
+for rendering.
+
+Camera Orientation is defined by a Rotation Axis and a Rotation Angle, applied to
+'default camera'.
+Default camera looks from (0,0,1) towards the origin, and the up direction
+is (0,1,0).
+
+For more information, see Coin documentation, Camera section.
+(https://developer.openinventor.com/UserGuides/Oiv9/Inventor_Mentor/\
+Cameras_and_Lights/Cameras.html)
+    """
+
+    Prop = namedtuple('Prop', ['Type', 'Group', 'Doc', 'Default'])
+
+    # PythonFeature object properties
+    PROPERTIES = {
+        "Projection": Prop(
+            "App::PropertyEnumeration",
+            "Camera",
+            QT_TRANSLATE_NOOP("Render", "Type of projection: Perspective/Orthographic"),
+            ["Perspective", "Orthographic"]),
+
+        "Placement": Prop(
+            "App::PropertyPlacement",
+            "",
+            QT_TRANSLATE_NOOP("Render", "Placement of camera"),
+            FreeCAD.Placement(FreeCAD.Vector(0, 0, 0), FreeCAD.Vector(0, 0, 1), 0)),
+
+        "ViewportMapping": Prop(
+            "App::PropertyEnumeration",
+            "Camera",
+            QT_TRANSLATE_NOOP("Render", "(See Coin documentation)"),
+            ["ADJUST_CAMERA", "LEAVE_ALONE", "CROP_VIEWPORT_FILL_FRAME",
+             "CROP_VIEWPORT_LINE_FRAME", "CROP_VIEWPORT_NO_FRAME"]),
+
+        "AspectRatio": Prop(
+            "App::PropertyFloat",
+            "Camera",
+            QT_TRANSLATE_NOOP("Render", "Ratio width/height of the camera."),
+            1.0),
+
+        "NearDistance": Prop(
+            "App::PropertyDistance",
+            "Camera",
+            QT_TRANSLATE_NOOP("Render", "Near distance, for clipping"),
+            0.0),
+
+        "FarDistance": Prop(
+            "App::PropertyDistance",
+            "Camera",
+            QT_TRANSLATE_NOOP("Render", "Far distance, for clipping"),
+            200.0),
+
+        "FocalDistance": Prop(
+            "App::PropertyDistance",
+            "Camera",
+            QT_TRANSLATE_NOOP("Render", "Focal distance"),
+            100.0),
+
+        "Height": Prop(
+            "App::PropertyLength",
+            "Camera",
+            QT_TRANSLATE_NOOP("Render", "Height, for orthographic camera"),
+            5.0),
+
+        "HeightAngle": Prop(
+            "App::PropertyAngle",
+            "Camera",
+            QT_TRANSLATE_NOOP("Render", "Height angle, for perspective camera"),
+            60),
+
+        "Shape": Prop(
+            "Part::PropertyPartShape",
+            "",
+            QT_TRANSLATE_NOOP("Render", "Shape of the camera"),
+            None),
+
+    }
+    # ~PythonFeature object properties
+
+    @classmethod
+    def setProperties(cls, fpo):
+        """Set underlying PythonFeature object's properties"""
+        for name in cls.PROPERTIES.keys() - set(fpo.PropertiesList):
+            fields = cls.PROPERTIES[name]
+            prop = fpo.addProperty(fields.Type, name, fields.Group, fields.Doc, 0)
+            setattr(prop, name, fields.Default)
+
+
+    def __init__(self, fpo):
+        """
+        Camera Initializer
+
+        Arguments
+        ---------
+        fpo: a FeaturePython object created with FreeCAD.addObject
+        """
+        self.type = "Camera"
+        fpo.Proxy = self
+        self.setProperties(fpo)
+
+    def onDocumentRestored(self, fpo):
+        """Callback triggered when document is restored"""
+        self.type = "Camera"
+        fpo.Proxy = self
+        self.setProperties(fpo)
+
+    def execute(self, fpo):
+        """Callback triggered on document recomputation (mandatory).
+        It mainly draws the camera representation on screen"""
+
+        size = 5
+        height = 10
+        # Square
+        poly1 = Part.makePolygon([(-size * 2, size, 0),
+                                  (size * 2, size, 0),
+                                  (size * 2, -size, 0),
+                                  (-size * 2, -size, 0),
+                                  (-size * 2, size, 0)])
+        # Triangle 1
+        poly2 = Part.makePolygon([(-size * 2, size, 0),
+                                  (0, 0, height * 2),
+                                  (-size * 2, -size, 0),
+                                  (-size * 2, size, 0)])
+        # Triangle 2
+        poly3 = Part.makePolygon([(size * 2, size, 0),
+                                  (0, 0, height * 2),
+                                  (size * 2, -size, 0),
+                                  (size * 2, size, 0)])
+        # Arrow (up direction)
+        poly4 = Part.makePolygon([(-size * 1.8, 1.2 * size, 0),
+                                  (0, 1.4 * size, 0),
+                                  (size * 1.8, 1.2 * size, 0),
+                                  (-size * 1.8, 1.2 * size, 0)])
+
+        fpo.Shape = Part.makeCompound([poly1, poly2, poly3, poly4])
+
+
+# ===========================================================================
+
+
+class ViewProviderCamera:
+    """View Provider of Camera class"""
+
+    def __init__(self, vobj):
+        vobj.Proxy = self
+        self.fpo = vobj.Object # Related FeaturePython object
+
+    def attach(self, vobj):
+        """Callback triggered when object is created/restored"""
+        self.fpo = vobj.Object
+
+    def getDisplayModes(self, _):
+        """Return a list of display modes"""
+        return ["Shaded"]
+
+    def getDefaultDisplayMode(self):
+        """Return the name of the default display mode.  It must be defined in
+        getDisplayModes."""
+        return "Shaded"
+
+    def setDisplayMode(self, mode):
+        """Map the display mode defined in attach with those defined in getDisplayModes.
+        Since they have the same names nothing needs to be done.
+        This method is optional."""
+        return mode
+
+    def getIcon(self):
+        """Return the icon which will appear in the tree view."""
+        return ":/icons/camera-photo.svg"
+
+    def setupContextMenu(self, vobj, menu):
+        """Setup the context menu associated to the object in tree view"""
+        action1 = QAction(QT_TRANSLATE_NOOP("Render", "Set GUI to this camera"),\
+                            menu)
+        QObject.connect(action1,\
+                SIGNAL("triggered()"),\
+                self.setGuiFromCamera)
+        menu.addAction(action1)
+
+        action2 = QAction(QT_TRANSLATE_NOOP("Render", "Set this camera to GUI"),\
+                            menu)
+        QObject.connect(action2,\
+                SIGNAL("triggered()"),\
+                self.setCameraFromGui)
+        menu.addAction(action2)
+
+    def updateData(self, fp, prop):
+        """Callback triggered when properties are modified"""
+        return
+
+    def setCameraFromGui(self):
+        """Set this camera from GUI camera"""
+
+        assert FreeCAD.GuiUp, "Cannot set camera from GUI: GUI is down"
+
+        fpo = self.fpo
+        node = FreeCADGui.ActiveDocument.ActiveView.getCameraNode()
+
+        VIEWPORTMAPPING = ("CROP_VIEWPORT_FILL_FRAME", "CROP_VIEWPORT_LINE_FRAME",
+                           "CROP_VIEWPORT_NO_FRAME", "ADJUST_CAMERA", " LEAVE_ALONE")
+
+        typ = node.getTypeId()
+        if typ == coin.SoPerspectiveCamera.getClassTypeId():
+            fpo.Projection = "Perspective"
+            fpo.HeightAngle = degrees(float(node.heightAngle.getValue()))
+        elif typ == coin.SoOrthographicCamera.getClassTypeId():
+            fpo.Projection = "Orthographic"
+            fpo.Height = float(node.height.getValue())
+        else:
+            raise ValueError("Unknown camera type")
+
+        pos = FreeCAD.Vector(node.position.getValue())
+        rot = FreeCAD.Rotation(*node.orientation.getValue().getValue())
+        fpo.Placement = FreeCAD.Placement(pos, rot)
+
+        fpo.NearDistance = float(node.nearDistance.getValue())
+        fpo.FarDistance = float(node.farDistance.getValue())
+        fpo.FocalDistance = float(node.focalDistance.getValue())
+        fpo.AspectRatio = float(node.aspectRatio.getValue())
+        fpo.ViewportMapping = VIEWPORTMAPPING[node.viewportMapping.getValue()]
+
+    def setGuiFromCamera(self):
+        """Set GUI camera to this camera"""
+
+        assert FreeCAD.GuiUp, "Cannot set GUI from camera: GUI is down"
+
+        fpo = self.fpo
+
+        FreeCADGui.ActiveDocument.ActiveView.setCameraType(fpo.Projection)
+
+        node = FreeCADGui.ActiveDocument.ActiveView.getCameraNode()
+
+        node.position.setValue(fpo.Placement.Base)
+        rot = fpo.Placement.Rotation
+        axis = coin.SbVec3f(rot.Axis.x, rot.Axis.y, rot.Axis.z)
+        node.orientation.setValue(axis, rot.Angle)
+
+        node.nearDistance.setValue(float(fpo.NearDistance))
+        node.farDistance.setValue(float(fpo.FarDistance))
+        node.focalDistance.setValue(float(fpo.FocalDistance))
+        node.aspectRatio.setValue(float(fpo.AspectRatio))
+        node.viewportMapping.setValue(getattr(node, fpo.ViewportMapping))
+
+        if fpo.Projection == "Orthographic":
+            node.height.setValue(float(fpo.Height))
+        elif fpo.Projection == "Perspective":
+            node.heightAngle.setValue(radians(float(fpo.HeightAngle)))
+
+    def __getstate__(self):
+        """Called while saving the document"""
+        return None
+
+    def __setstate__(self, state):
+        """Called while restoring document"""
+        return None
+
+
+
+# ===========================================================================
+
+
+def setCamFromCoinString(cam, camstr):
+    """Set a Camera object from a string containing a camera description in Open Inventor
+    format
+
+    camstr: a string in OpenInventor format, ex:
+    #Inventor V2.1 ascii
+
+
+    PerspectiveCamera {
+     viewportMapping ADJUST_CAMERA
+     position 0 -1.3207401 0.82241058
+     orientation 0.99999666 0 0  0.26732138
+     nearDistance 1.6108983
+     farDistance 6611.4492
+     aspectRatio 1
+     focalDistance 5
+     heightAngle 0.78539819
+
+    }
+
+    or (ortho camera):
+    #Inventor V2.1 ascii
+
+
+    OrthographicCamera {
+     viewportMapping ADJUST_CAMERA
+     position 0 0 1
+     orientation 0 0 1  0
+     nearDistance 0.99900001
+     farDistance 1.001
+     aspectRatio 1
+     focalDistance 5
+     height 4.1421356
+
+    }"""
+
+    # Split, clean and tokenize
+    camdata = [y for y in [shlex.split(x, comments=True)\
+                            for x in camstr.split('\n')] if y]
+    camdict = {y[0]:y[1:] for y in camdata}
+
+    cam.Projection = camdata[0][0][0:-6] # Data block should start with Cam Type...
+    assert cam.Projection in ('Perspective', 'Orthographic'),\
+        "Invalid camera header in camera string"
+    try:
+        pos = FreeCAD.Vector(camdict["position"][0:3])
+        rot = FreeCAD.Rotation(FreeCAD.Vector(camdict["orientation"][0:3]),
+                               degrees(float(camdict["orientation"][3])))
+        cam.Placement = FreeCAD.Placement(pos, rot)
+        cam.FocalDistance = float(camdict["focalDistance"][0])
+        cam.AspectRatio = float(camdict["aspectRatio"][0])
+        cam.ViewportMapping = str(camdict["viewportMapping"][0])
+    except KeyError as err:
+        raise ValueError("Missing field in camera string: {}".format(err) )
+
+    # It may happen that near & far distances are not set in camstr...
+    try:
+        cam.NearDistance = float(camdict["nearDistance"][0])
+    except KeyError:
+        pass
+    try:
+        cam.FarDistance = float(camdict["farDistance"][0])
+    except KeyError:
+        pass
+
+    if cam.Projection == "Orthographic":
+        cam.Height = float(camdict["height"][0])
+    elif cam.Projection == "Perspective":
+        cam.HeightAngle = degrees(float(camdict["heightAngle"][0]))
+
+
+def getCoinStringFromCam(cam):
+    """Return camera data in Coin string format
+
+    cam: a Camera object"""
+
+    def checkEnum(field):
+        'Check if the enum field value is valid'
+        assert getattr(cam, field) in Camera.PROPERTIES[field].Default,\
+                "Invalid %s value" %field
+
+    checkEnum("Projection")
+    checkEnum("ViewportMapping")
+
+    res = list()
+    res.append("#Inventor V2.1 ascii\n\n\n")
+    res.append("{}Camera {{".format(cam.Projection))
+    res.append(" viewportMapping {}".format(cam.ViewportMapping))
+    res.append(" position {} {} {}".format(*cam.Placement.Base))
+    res.append(" orientation {} {} {} {}"\
+            .format(*cam.Placement.Rotation.Axis,
+                    cam.Placement.Rotation.Angle))
+    res.append(" nearDistance {}".format(float(cam.NearDistance)))
+    res.append(" farDistance {}".format(float(cam.FarDistance)))
+    res.append(" aspectRatio {}".format(float(cam.AspectRatio)))
+    res.append(" focalDistance {}".format(float(cam.FocalDistance)))
+    if cam.Projection == "Orthographic":
+        res.append(" height {}".format(float(cam.Height)))
+    elif cam.Projection == "Perspective":
+        res.append(" heightAngle {}".format(radians(cam.HeightAngle)))
+    res.append("}\n")
+    return '\n'.join(res)
+
+def retrieveLegacyCamera(project):
+    """For backward compatibility: Retrieve legacy camera information in rendering projects
+    and transform it into Camera object"""
+    assert isinstance(project.Camera, str), "Project's Camera property should contain a string"""
+    fpo = createCamera()
+    setCamFromCoinString(fpo, project.Camera)

--- a/Render.py
+++ b/Render.py
@@ -30,11 +30,13 @@ import re
 import tempfile
 import importlib
 import math
+from types import SimpleNamespace
 
 import FreeCAD
 import Draft
 import Part
 import MeshPart
+import Camera
 
 if FreeCAD.GuiUp:
     from PySide import QtCore, QtGui
@@ -120,7 +122,7 @@ class RenderViewCommand:
             else:
                 if o.isDerivedFrom("Part::Feature") or o.isDerivedFrom("Mesh::Feature"):
                     objs.append(o)
-                if o.isDerivedFrom("App::FeaturePython") and o.Proxy.type in ['PointLight']:
+                if o.isDerivedFrom("App::FeaturePython") and o.Proxy.type in ['PointLight','Camera']:
                     objs.append(o)
         if not project:
             for o in FreeCAD.ActiveDocument.Objects:
@@ -209,6 +211,18 @@ class RenderExternalCommand:
             import ImageGui
             ImageGui.open(img)
 
+class CameraCommand:
+
+    "Create a Camera object"
+
+    def GetResources(self):
+
+        return {'Pixmap'  : ":/icons/camera-photo.svg",
+                'MenuText': QtCore.QT_TRANSLATE_NOOP("Render", "Create Camera"),
+                'ToolTip' : QtCore.QT_TRANSLATE_NOOP("Render", "Create a Camera object from the current camera position")}
+
+    def Activated(self):
+        Camera.createCamera()
 
 
 class Project:
@@ -232,8 +246,6 @@ class Project:
             obj.DelayedBuild = True
         if not "Template" in obj.PropertiesList:
             obj.addProperty("App::PropertyFile","Template","Render", QT_TRANSLATE_NOOP("App::Property","The template to be used by this rendering"))
-        if not "Camera" in obj.PropertiesList:
-            obj.addProperty("App::PropertyString","Camera","Render", QT_TRANSLATE_NOOP("App::Property","The camera data to be used"))
         if not "PageResult" in obj.PropertiesList:
             obj.addProperty("App::PropertyFileIncluded", "PageResult","Render", QT_TRANSLATE_NOOP("App::Property","The result file to be sent to the renderer"))
         if not "Group" in obj.PropertiesList:
@@ -262,9 +274,7 @@ class Project:
 
 
     def execute(self,obj):
-
         return True
-
 
     def onChanged(self,obj,prop):
 
@@ -273,76 +283,34 @@ class Project:
                 for view in obj.Group:
                     view.touch()
 
-
-
-
     def setCamera(self,obj):
-
         if FreeCAD.GuiUp:
             import FreeCADGui
             obj.Camera = FreeCADGui.ActiveDocument.ActiveView.getCamera()
 
 
-    def writeCamera(self,obj,renderer):
+    def writeCamera(self, view, renderer):
+        """Get a rendering string from a camera. Camera can be either a string in Coin
+        format or a Camera object
 
-        # camdata contains a string in OpenInventor format
-        # ex:
-        # #Inventor V2.1 ascii
-        #
-        #
-        # PerspectiveCamera {
-        #  viewportMapping ADJUST_CAMERA
-        #  position 0 -1.3207401 0.82241058
-        #  orientation 0.99999666 0 0  0.26732138
-        #  nearDistance 1.6108983
-        #  farDistance 6611.4492
-        #  aspectRatio 1
-        #  focalDistance 5
-        #  heightAngle 0.78539819
-        #
-        # }
-        #
-        # or (ortho camera):
-        #
-        # #Inventor V2.1 ascii
-        #
-        #
-        # OrthographicCamera {
-        #  viewportMapping ADJUST_CAMERA
-        #  position 0 0 1
-        #  orientation 0 0 1  0
-        #  nearDistance 0.99900001
-        #  farDistance 1.001
-        #  aspectRatio 1
-        #  focalDistance 5
-        #  height 4.1421356
-        #
-        # }
+        Parameters:
+        view: a view of the camera to render.
+        renderer: the renderer module to use
 
-        if not obj.Camera:
-            self.setCamera(obj)
-            if not obj.Camera:
-                FreeCAD.Console.PrintError(translate("Render","Unable to set the camera"))
-                return ""
+        Returns: a rendering string, obtained from the renderer module
+        """
 
-        camdata = obj.Camera.split("\n")
-        cam = ""
-        pos = [float(p) for p in camdata[5].split()[-3:]]
-        pos = FreeCAD.Vector(pos)
-        rot = [float(p) for p in camdata[6].split()[-4:]]
-        rot = FreeCAD.Rotation(FreeCAD.Vector(rot[0],rot[1],rot[2]),math.degrees(rot[3]))
-        target = rot.multVec(FreeCAD.Vector(0,0,-1))
-        target.multiply(float(camdata[10].split()[-1]))
-        target = pos.add(target)
-        up = rot.multVec(FreeCAD.Vector(0,1,0))
+        cam = view.Source
+        aspectRatio = cam.AspectRatio
+        pos = cam.Placement.Base
+        rot = cam.Placement.Rotation
+        target = pos.add(rot.multVec(FreeCAD.Vector(0, 0, -1)).multiply(aspectRatio))
+        up = rot.multVec(FreeCAD.Vector(0, 1, 0))
 
-        return renderer.writeCamera(pos,rot,up,target)
-
+        return renderer.writeCamera(pos, rot, up, target)
 
     def writePointLight(self,view,renderer):
         """Gets a rendering string for a point light object
-
-           This method should be called only by writeObject, as a hook for point lights
 
            Parameters:
            view: the view of the point light (contains the point light data)
@@ -365,21 +333,8 @@ class Project:
         return renderer.writePointLight(view,location,color,power)
 
 
-    def writeObject(self,view,renderer):
-        """Gets a rendering string for an object
-
-           Parameters:
-           view: the view of the object (contains the object data)
-           renderer: the renderer module to use (callback)
-        """
-
-        if not view.Source:
-            return ""
-
-        # point light hook
-        proxy = getattr(view.Source,"Proxy",None)
-        if getattr(proxy,"type",None) == "PointLight":
-            return self.writePointLight(view,renderer)
+    def writeMesh(self,view,renderer):
+        """Get a rendering string for a mesh object"""
 
         # get color and alpha
         mat = None
@@ -433,6 +388,33 @@ class Project:
             return ""
 
         return renderer.writeObject(view,mesh,color,alpha)
+
+
+    def writeObject(self,view,renderer):
+        """Gets a rendering string for the view of an object
+
+           Parameters:
+           view: the view of the object (contains the object data)
+           renderer: the renderer module to use (callback)
+        """
+
+        if not view.Source:
+            return ""
+
+        # Special objects: camera, lights etc.
+        try:
+            objtype = view.Source.Proxy.type
+        except AttributeError:
+            pass
+        else:
+            if objtype == "PointLight":
+                return self.writePointLight(view, renderer)
+            if objtype == "Camera":
+                return self.writeCamera(view, renderer)
+
+        # Mesh
+        return self.writeMesh(view, renderer)
+
 
 
     def writeGroundPlane(self,obj,renderer):
@@ -502,8 +484,15 @@ class Project:
         if not template:
             return
 
-        # get a camera string
-        cam = self.writeCamera(obj,renderer)
+        # get active camera (will be used if no camera is present in the scene)
+        if FreeCAD.GuiUp:
+            import FreeCADGui
+            dummycamview = SimpleNamespace()
+            dummycamview.Source = SimpleNamespace()
+            Camera.setCamFromCoinString(dummycamview.Source,
+                    FreeCADGui.ActiveDocument.ActiveView.getCamera())
+            cam = self.writeCamera(dummycamview,
+                    renderer)
 
         # get objects rendering strings (including lights objects)
         # and add a ground plane if required
@@ -595,7 +584,8 @@ class ViewProviderProject:
     def setupContextMenu(self,vobj,menu):
         from PySide import QtCore,QtGui
         import FreeCADGui
-        action1 = QtGui.QAction(QtGui.QIcon(":/icons/camera-photo.svg"),"Save camera position",menu)
+        action1 = QtGui.QAction(QtGui.QIcon(":/icons/camera-photo.svg"),
+                QT_TRANSLATE_NOOP("Render","Set to camera current position"),menu)
         QtCore.QObject.connect(action1,QtCore.SIGNAL("triggered()"),self.setCamera)
         menu.addAction(action1)
         action2 = QtGui.QAction(QtGui.QIcon(os.path.join(os.path.dirname(__file__),"icons","Render.svg")),"Render",menu)
@@ -701,6 +691,8 @@ if FreeCAD.GuiUp:
     for renderer in Renderers:
         FreeCADGui.addCommand('Render_'+renderer, RenderProjectCommand(renderer))
         RenderCommands.append('Render_'+renderer)
+    FreeCADGui.addCommand('Render_Camera', CameraCommand())
+    RenderCommands.append('Render_Camera')
     FreeCADGui.addCommand('Render_View', RenderViewCommand())
     RenderCommands.append('Render_View')
     FreeCADGui.addCommand('Render_Render', RenderCommand())

--- a/icons/Raytrace_Camera.svg
+++ b/icons/Raytrace_Camera.svg
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" width="64px" height="64px" id="svg2383" sodipodi:version="0.32" inkscape:version="0.48.5 r10040" sodipodi:docname="Raytrace_Camera.svg" inkscape:output_extension="org.inkscape.output.svg.inkscape" version="1.1">
+  <defs id="defs2385">
+    <linearGradient id="linearGradient3980">
+      <stop style="stop-color:#555753;stop-opacity:1" offset="0" id="stop3982"/>
+      <stop style="stop-color:#d3d7cf;stop-opacity:1" offset="1" id="stop3984"/>
+    </linearGradient>
+    <linearGradient inkscape:collect="always" id="linearGradient3938">
+      <stop style="stop-color:#555753;stop-opacity:1" offset="0" id="stop3940"/>
+      <stop style="stop-color:#888a85;stop-opacity:1" offset="1" id="stop3942"/>
+    </linearGradient>
+    <linearGradient inkscape:collect="always" id="linearGradient3930">
+      <stop style="stop-color:#888a85;stop-opacity:1" offset="0" id="stop3932"/>
+      <stop style="stop-color:#babdb6;stop-opacity:1" offset="1" id="stop3934"/>
+    </linearGradient>
+    <linearGradient inkscape:collect="always" id="linearGradient3922">
+      <stop style="stop-color:#888a85;stop-opacity:1" offset="0" id="stop3924"/>
+      <stop style="stop-color:#babdb6;stop-opacity:1" offset="1" id="stop3926"/>
+    </linearGradient>
+    <linearGradient inkscape:collect="always" id="linearGradient3914">
+      <stop style="stop-color:#babdb6;stop-opacity:1" offset="0" id="stop3916"/>
+      <stop style="stop-color:#d3d7cf;stop-opacity:1" offset="1" id="stop3918"/>
+    </linearGradient>
+    <linearGradient inkscape:collect="always" id="linearGradient3822">
+      <stop style="stop-color:#204a87;stop-opacity:1" offset="0" id="stop3824"/>
+      <stop style="stop-color:#3465a4;stop-opacity:1" offset="1" id="stop3826"/>
+    </linearGradient>
+    <linearGradient inkscape:collect="always" id="linearGradient3812">
+      <stop style="stop-color:#3465a4;stop-opacity:1" offset="0" id="stop3814"/>
+      <stop style="stop-color:#729fcf;stop-opacity:1" offset="1" id="stop3816"/>
+    </linearGradient>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3193" id="linearGradient3798" x1="37.568619" y1="52.091393" x2="61.699051" y2="52.091393" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.8996999,8.9368292e-2,0,1.077201,-1.2010146,-10.825301)"/>
+    <radialGradient inkscape:collect="always" xlink:href="#linearGradient3776" id="radialGradient3788" gradientUnits="userSpaceOnUse" gradientTransform="matrix(-9.0804555e-2,0.6417536,-0.5088409,-7.1997875e-2,108.69412,-58.786895)" cx="116.67953" cy="88.451447" fx="116.67953" fy="88.451447" r="19.467436"/>
+    <linearGradient id="linearGradient3776">
+      <stop id="stop3778" offset="0" style="stop-color:#ffffff;stop-opacity:1;"/>
+      <stop id="stop3780" offset="1" style="stop-color:#120055;stop-opacity:1;"/>
+    </linearGradient>
+    <radialGradient inkscape:collect="always" xlink:href="#linearGradient3776" id="radialGradient3786" gradientUnits="userSpaceOnUse" gradientTransform="matrix(-0.8044586,0.2888218,-0.1885928,-0.5252895,188.14537,24.979398)" cx="161.98506" cy="80.207535" fx="161.98506" fy="80.207535" r="19.467436"/>
+    <linearGradient id="linearGradient3558">
+      <stop id="stop3560" offset="0" style="stop-color:#777777;stop-opacity:1;"/>
+      <stop id="stop3562" offset="1" style="stop-color:#c5c5c5;stop-opacity:1;"/>
+    </linearGradient>
+    <linearGradient id="linearGradient3377">
+      <stop id="stop3379" offset="0" style="stop-color:#faff2b;stop-opacity:1;"/>
+      <stop id="stop3381" offset="1" style="stop-color:#ffaa00;stop-opacity:1;"/>
+    </linearGradient>
+    <linearGradient id="linearGradient3362">
+      <stop id="stop3364" offset="0" style="stop-color:#85ceff;stop-opacity:1;"/>
+      <stop id="stop3366" offset="1" style="stop-color:#004267;stop-opacity:1;"/>
+    </linearGradient>
+    <linearGradient id="linearGradient3193">
+      <stop id="stop3195" offset="0" style="stop-color:#68ff00;stop-opacity:1;"/>
+      <stop id="stop3197" offset="1" style="stop-color:#078b00;stop-opacity:1;"/>
+    </linearGradient>
+    <linearGradient id="linearGradient3185">
+      <stop style="stop-color:#ffffff;stop-opacity:1;" offset="0" id="stop3187"/>
+      <stop style="stop-color:#ffffff;stop-opacity:0;" offset="1" id="stop3189"/>
+    </linearGradient>
+    <linearGradient id="linearGradient3175">
+      <stop style="stop-color:#ababab;stop-opacity:1;" offset="0" id="stop3177"/>
+      <stop style="stop-color:#ffffff;stop-opacity:1;" offset="1" id="stop3179"/>
+    </linearGradient>
+    <inkscape:perspective sodipodi:type="inkscape:persp3d" inkscape:vp_x="0 : 32 : 1" inkscape:vp_y="6.1230318e-14 : 1000 : 0" inkscape:vp_z="64 : 32 : 1" inkscape:persp3d-origin="32 : 21.333333 : 1" id="perspective2391"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3558" id="linearGradient3556" x1="2.0698812" y1="38.643501" x2="34.403511" y2="8.8164501" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.4301164,0,0,1.5884412,-0.8116844,-2.0846154)"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3558" id="linearGradient4466" x1="11.081819" y1="48.272728" x2="29.281818" y2="33.727276" gradientUnits="userSpaceOnUse" gradientTransform="translate(1.028519,-3.028519)"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3558" id="linearGradient4476" x1="27.990908" y1="28.818182" x2="48.918179" y2="28.818182" gradientUnits="userSpaceOnUse"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3980" id="linearGradient4491" gradientUnits="userSpaceOnUse" x1="37.559368" y1="38.70792" x2="37.612301" y2="16.833065"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3558" id="linearGradient4493" gradientUnits="userSpaceOnUse" x1="27.990908" y1="28.818182" x2="48.918179" y2="28.818182"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3558" id="linearGradient4495" gradientUnits="userSpaceOnUse" gradientTransform="translate(1.028519,-3.028519)" x1="11.081819" y1="48.272728" x2="29.281818" y2="33.727276"/>
+    <radialGradient inkscape:collect="always" xlink:href="#linearGradient3776" id="radialGradient4501" gradientUnits="userSpaceOnUse" gradientTransform="matrix(-0.8044586,0.2888218,-0.1885928,-0.5252895,226.96694,25.168008)" cx="161.98506" cy="80.207535" fx="161.98506" fy="80.207535" r="19.467436"/>
+    <radialGradient inkscape:collect="always" xlink:href="#linearGradient3776" id="radialGradient4503" gradientUnits="userSpaceOnUse" gradientTransform="matrix(-0.09080455,0.6417536,-0.5088409,-0.07199787,147.51569,-58.598285)" cx="116.67953" cy="88.451447" fx="116.67953" fy="88.451447" r="19.467436"/>
+    <radialGradient inkscape:collect="always" xlink:href="#linearGradient3776" id="radialGradient3037" gradientUnits="userSpaceOnUse" gradientTransform="matrix(-0.09080455,0.6417536,-0.5088409,-0.07199787,149.18703,-55.384163)" cx="116.67953" cy="88.451447" fx="116.67953" fy="88.451447" r="19.467436"/>
+    <radialGradient inkscape:collect="always" xlink:href="#linearGradient3776" id="radialGradient3040" gradientUnits="userSpaceOnUse" gradientTransform="matrix(-0.8044586,0.2888218,-0.1885928,-0.5252895,228.63828,28.38213)" cx="161.98506" cy="80.207535" fx="161.98506" fy="80.207535" r="19.467436"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3812" id="linearGradient3818" x1="53.840504" y1="19.297924" x2="51.077038" y2="5.2260008" gradientUnits="userSpaceOnUse"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3822" id="linearGradient3828" x1="38.430935" y1="21.593138" x2="35.372253" y2="8.9972916" gradientUnits="userSpaceOnUse"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3914" id="linearGradient3920" x1="-22.900515" y1="31.200813" x2="-22.282394" y2="25.216684" gradientUnits="userSpaceOnUse"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3922" id="linearGradient3928" x1="-27.632151" y1="45.427464" x2="-30.854929" y2="34.224621" gradientUnits="userSpaceOnUse"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3930" id="linearGradient3936" x1="-26.850866" y1="57.548725" x2="-26.636213" y2="50.729603" gradientUnits="userSpaceOnUse"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3938" id="linearGradient3944" x1="-12.101327" y1="41.339977" x2="-15.968256" y2="32.850868" gradientUnits="userSpaceOnUse"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3558-6" id="linearGradient4491-5" gradientUnits="userSpaceOnUse" x1="27.990908" y1="28.818182" x2="48.918179" y2="28.818182"/>
+    <linearGradient id="linearGradient3558-6">
+      <stop id="stop3560-2" offset="0" style="stop-color:#777777;stop-opacity:1;"/>
+      <stop id="stop3562-9" offset="1" style="stop-color:#c5c5c5;stop-opacity:1;"/>
+    </linearGradient>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3980" id="linearGradient4003" gradientUnits="userSpaceOnUse" x1="37.559368" y1="38.70792" x2="37.612301" y2="16.833065"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3914" id="linearGradient4005" gradientUnits="userSpaceOnUse" x1="-22.900515" y1="31.200813" x2="-22.282394" y2="25.216684"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3930" id="linearGradient4007" gradientUnits="userSpaceOnUse" x1="-26.850866" y1="57.548725" x2="-26.636213" y2="50.729603"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3922" id="linearGradient4009" gradientUnits="userSpaceOnUse" x1="-27.632151" y1="45.427464" x2="-30.854929" y2="34.224621"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3938" id="linearGradient4011" gradientUnits="userSpaceOnUse" x1="-12.101327" y1="41.339977" x2="-15.968256" y2="32.850868"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3806" id="linearGradient3012" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.4500001,0,0,1.4705882,-27.45,-15.05882)" x1="39.263832" y1="20.978374" x2="43.478561" y2="42.076672"/>
+    <linearGradient id="linearGradient3806">
+      <stop style="stop-color:#8ae234;stop-opacity:1" offset="0" id="stop3808"/>
+      <stop style="stop-color:#4e9a06;stop-opacity:1" offset="1" id="stop3810"/>
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview id="base" pagecolor="#ffffff" bordercolor="#666666" borderopacity="1.0" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:zoom="14.371351" inkscape:cx="40.619286" inkscape:cy="15.206791" inkscape:current-layer="layer1" showgrid="true" inkscape:document-units="px" inkscape:grid-bbox="true" inkscape:window-width="1600" inkscape:window-height="837" inkscape:window-x="0" inkscape:window-y="27" inkscape:snap-global="true" inkscape:window-maximized="1" inkscape:snap-bbox="true" inkscape:snap-nodes="false">
+    <inkscape:grid type="xygrid" id="grid3025" empspacing="2" visible="true" enabled="true" snapvisiblegridlinesonly="true"/>
+  </sodipodi:namedview>
+  <metadata id="metadata2388">
+    <rdf:RDF>
+      <cc:Work rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>$committer</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:title>Raytrace_Camera</dc:title>
+        <dc:date>2011-10-10</dc:date>
+        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier>FreeCAD/src/Mod/Raytracing/Gui/Resources/icons/Raytrace_Camera.svg</dc:identifier>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <cc:license>https://www.gnu.org/copyleft/lesser.html</cc:license>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>[agryson] Alexander Gryson</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g id="layer1" inkscape:label="Layer 1" inkscape:groupmode="layer">
+    <path sodipodi:nodetypes="ccccc" inkscape:connector-curvature="0" id="path3027" d="M 61,5 61,23 45,21 45,3 z" style="fill:url(#linearGradient3818);stroke:#0b1521;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1;fill-opacity:1"/>
+    <path sodipodi:nodetypes="ccccc" inkscape:connector-curvature="0" id="path3029" d="M 45,3 29,9 29,27 45,21 z" style="fill:url(#linearGradient3828);stroke:#0b1521;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1;fill-opacity:1"/>
+    <path sodipodi:nodetypes="ccccc" inkscape:connector-curvature="0" id="path3031" d="M 29,27 49,31 61,23 45,21 z" style="fill:#729fcf;stroke:#0b1521;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"/>
+    <g id="g4484" transform="matrix(0.9168094,-0.24770369,0.23279633,0.86163377,-33.003716,15.008646)" style="stroke:#2e3436;stroke-width:2.17234993"/>
+    <path style="fill:none;stroke:#729fcf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="m 47,5.1739572 -0.01652,14.1043748 12.041123,1.500257 0.01019,-14.0569205 z" id="path3810" inkscape:connector-curvature="0" sodipodi:nodetypes="ccccc"/>
+    <path style="fill:none;stroke:#3465a4;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="m 30.985291,10.356944 1e-6,13.789008 12.017718,-4.514331 -1e-6,-13.7767079 z" id="path3820" inkscape:connector-curvature="0" sodipodi:nodetypes="ccccc"/>
+    <g id="g3989" transform="translate(40,0)">
+      <path sodipodi:type="arc" style="fill:url(#linearGradient4003);fill-opacity:1;fill-rule:evenodd;stroke:#2e3436;stroke-width:2.42158961;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" id="path4468" sodipodi:cx="38.454544" sodipodi:cy="28.818182" sodipodi:rx="9.363636" sodipodi:ry="14.090909" d="m 47.81818,28.818182 c 0,7.782194 -4.192243,14.090909 -9.363636,14.090909 -5.171393,0 -9.363636,-6.308715 -9.363636,-14.090909 0,-7.782194 4.192243,-14.090909 9.363636,-14.090909 5.171393,0 9.363636,6.308715 9.363636,14.090909 z" transform="matrix(0.92789463,-0.2506987,0.1851037,0.68511215,-49.016116,16.896818)"/>
+      <path sodipodi:type="arc" style="fill:none;stroke:#d3d7cf;stroke-width:3.07285166;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" id="path4468-1" sodipodi:cx="38.454544" sodipodi:cy="28.818182" sodipodi:rx="9.363636" sodipodi:ry="14.090909" d="m 47.81818,28.818182 c 0,7.782194 -4.192243,14.090909 -9.363636,14.090909 -5.171393,0 -9.363636,-6.308715 -9.363636,-14.090909 0,-7.782194 4.192243,-14.090909 9.363636,-14.090909 5.171393,0 9.363636,6.308715 9.363636,14.090909 z" transform="matrix(0.71581695,-0.20182115,0.14279677,0.55153902,-39.641558,18.866588)"/>
+      <path sodipodi:type="arc" style="fill:none;stroke:#2e3436;stroke-width:3.86602902;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" id="path4478" sodipodi:cx="38.454544" sodipodi:cy="28.818182" sodipodi:rx="9.363636" sodipodi:ry="14.090909" d="m 47.81818,28.818182 c 0,7.782194 -4.192243,14.090909 -9.363636,14.090909 -5.171393,0 -9.363636,-6.308715 -9.363636,-14.090909 0,-7.782194 4.192243,-14.090909 9.363636,-14.090909 5.171393,0 9.363636,6.308715 9.363636,14.090909 z" transform="matrix(0.58124762,-0.15704156,0.11593734,0.42911128,-35.39446,22.31826)"/>
+      <path inkscape:connector-curvature="0" id="path3840" d="m -7,25 -16,10 -14,-6 18,-8 z" style="fill:url(#linearGradient4005);fill-opacity:1;stroke:#2e3436;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"/>
+      <path sodipodi:nodetypes="ccccc" inkscape:connector-curvature="0" id="path3842" d="m -28,47 -3,12 6,2 3,-13 z" style="fill:url(#linearGradient4007);fill-opacity:1;stroke:#2e3436;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"/>
+      <path sodipodi:nodetypes="ccccc" inkscape:connector-curvature="0" id="path3844" d="m -25,61 6,-4 3,-12 -6,3 z" style="fill:#888a85;stroke:#2e3436;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"/>
+      <path sodipodi:nodetypes="ccccc" inkscape:connector-curvature="0" id="path3836" d="m -37,29 2,16 14,6 -2,-16 z" style="fill:url(#linearGradient4009);fill-opacity:1;stroke:#2e3436;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"/>
+      <path inkscape:connector-curvature="0" id="path3838" d="M -21,51 -5,39 -7,25 -23,35 z" style="fill:url(#linearGradient4011);fill-opacity:1;stroke:#2e3436;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"/>
+      <path sodipodi:nodetypes="ccccc" inkscape:connector-curvature="0" id="path3840-3" d="M -11.591454,25.556663 -23.139166,32.75646 -32.104374,28.947813 -18.87823,23.12177 z" style="fill:none;stroke:#d3d7cf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"/>
+      <path sodipodi:nodetypes="ccccc" inkscape:connector-curvature="0" id="path3836-6" d="m -34.58501,32.207765 1.425941,11.424925 9.751095,4.164752 -1.425941,-11.40753 z" style="fill:none;stroke:#babdb6;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"/>
+      <path sodipodi:nodetypes="ccccc" inkscape:connector-curvature="0" id="path3836-6-7" d="m -26.855917,50.667353 -1.779455,7.0324 2.208047,0.713705 1.571549,-6.905504 z" style="fill:none;stroke:#babdb6;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"/>
+      <path sodipodi:nodetypes="ccccc" inkscape:connector-curvature="0" id="path3836-6-3" d="M -20.866159,36.047773 -19.434036,47.347051 -7.1246222,38.105519 -8.53564,28.318388 z" style="fill:none;stroke:#888a85;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"/>
+    </g>
+    <g style="display:inline" inkscape:label="Layer 1" id="layer1-3" transform="matrix(0.25718857,-0.24084388,0.49414437,0.17507928,21.815762,51.580429)">
+      <path inkscape:export-ydpi="4.1683898" inkscape:export-xdpi="4.1683898" inkscape:export-filename="/home/yorik/Documents/Lab/Draft/icons/changeprop.png" sodipodi:nodetypes="cccccccc" id="path3343" d="m 35.907323,8.8968626 0,14.1031384 -32.907323,0 10e-8,23.505231 32.9073229,0 0,14.103138 L 64.1136,34.752616 z" style="fill:url(#linearGradient3012);fill-opacity:1;fill-rule:evenodd;stroke:#172a04;stroke-width:4.9380455;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" inkscape:connector-curvature="0"/>
+      <path inkscape:export-ydpi="4.1683898" inkscape:export-xdpi="4.1683898" inkscape:export-filename="/home/yorik/Documents/Lab/Draft/icons/changeprop.png" sodipodi:nodetypes="cccccccc" id="path3343-2" d="M 41.394008,22.840387 40.364826,27.513932 9.0663148,27.188206 9.28053,42.471815 l 33.191442,-0.161637 -0.0297,6.891548 13.905071,-12.791212 z" style="fill:none;stroke:#8ae234;stroke-width:4.9380455;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" inkscape:connector-curvature="0"/>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
This camera object allows to record a particular position of active Coin
camera and reuse it in rendering process.
Camera object can simply be inserted as a "view" in rendering projects,
like other rendered objects, and will thereby be exported to renderers.
Benefits for users are:
- User can easily access Camera settings for validation and tweaking.
- Camera object has a graphical representation that helps user see
where Camera is and where it looks to
- User can create as many Cameras as he/she wishes, to record various
points of views and consequently reuse them in rendering.
- User can reset active Coin camera back to any Camera object position,
in order to retrieve previous points of views
- User can opt to have no Camera in a given project: in that case, the
active Coin camera position will be used for rendering.

Camera object replaces the legacy handling of camera in rendering
projects as a (scarcely editable) project property. Camera property in
rendering projects is thus deprecated. However, a backward compatibility
function (Camera.retrieveLegacyCamera) is provided, which can create a
Camera object from the Camera field of a given rendering project and 
avoid data loss.

This PR answers the forum thread: https://forum.freecadweb.org/viewtopic.php?f=10&t=40839&p=348101&hilit=camera#p348101