### PR TITLE
Linting (and some refactoring)

### DIFF
--- a/InitGui.py
+++ b/InitGui.py
@@ -1,36 +1,37 @@
-#***************************************************************************
-#*                                                                         *
-#*   Copyright (c) 2017 Yorik van Havre <yorik@uncreated.net>              * 
-#*                                                                         *
-#*   This program is free software; you can redistribute it and/or modify  *
-#*   it under the terms of the GNU Lesser General Public License (LGPL)    *
-#*   as published by the Free Software Foundation; either version 2 of     *
-#*   the License, or (at your option) any later version.                   *
-#*   for detail see the LICENCE text file.                                 *
-#*                                                                         *
-#*   This program is distributed in the hope that it will be useful,       *
-#*   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
-#*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
-#*   GNU Library General Public License for more details.                  *
-#*                                                                         *
-#*   You should have received a copy of the GNU Library General Public     *
-#*   License along with this program; if not, write to the Free Software   *
-#*   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
-#*   USA                                                                   *
-#*                                                                         *
-#***************************************************************************
+# ***************************************************************************
+# *                                                                         *
+# *   Copyright (c) 2017 Yorik van Havre <yorik@uncreated.net>              *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   This program is distributed in the hope that it will be useful,       *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with this program; if not, write to the Free Software   *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+"""Gui initialization module for Render Workbench"""
+
+import FreeCADGui as Gui
 
 
-
-class RenderWorkbench (Workbench):
-
-
-    "the Render Workbench"
+class RenderWorkbench(Gui.Workbench):
+    "The Render Workbench"
 
     def __init__(self):
         self.__class__.MenuText = "Render"
-        self.__class__.ToolTip = "The Render module is a modern replacement for the Raytracing module"
-        self.__class__.Icon='''
+        self.__class__.ToolTip = ("The Render module is a modern replacement"
+                                  " for the Raytracing module")
+        self.__class__.Icon = '''
 /* XPM */
 static char * Render_xpm[] = {
 "16 16 33 1",
@@ -85,23 +86,24 @@ static char * Render_xpm[] = {
 "                "};
 '''
 
-
     def Initialize(self):
+        """When the workbench is first loaded."""
+        # pylint: disable=no-self-use, import-outside-toplevel
+        from PySide.QtCore import QT_TRANSLATE_NOOP
+        from FreeCAD import Console
+        from FreeCADGui import addIconPath, addPreferencePage
+        from Render import RENDER_COMMANDS, ICONPATH, PREFPAGE
 
-        def QT_TRANSLATE_NOOP(scope, text):
-            return text
+        commands = RENDER_COMMANDS
+        self.appendToolbar(QT_TRANSLATE_NOOP("Workbench", "Render"), commands)
+        self.appendMenu(QT_TRANSLATE_NOOP("Workbench", "&Render"), commands)
+        addIconPath(ICONPATH)
+        addPreferencePage(PREFPAGE, "Render")
+        Console.PrintLog("Loading Render module...done\n")
 
-        import Render
-        commands = Render.RenderCommands
-        self.appendToolbar(QT_TRANSLATE_NOOP("Workbench","Render"),commands)
-        self.appendMenu(QT_TRANSLATE_NOOP("Workbench","&Render"),commands)
-        FreeCADGui.addIconPath(Render.iconpath)
-        FreeCADGui.addPreferencePage(Render.prefpage,"Render")
-        Log ('Loading Render module...done\n')
-
-    def GetClassName(self): 
+    def GetClassName(self):  # pylint: disable=no-self-use
+        """Type of workbench"""
         return "Gui::PythonWorkbench"
 
-FreeCADGui.addWorkbench(RenderWorkbench)
 
-
+Gui.addWorkbench(RenderWorkbench)

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,481 @@
+		  GNU LIBRARY GENERAL PUBLIC LICENSE
+		       Version 2, June 1991
+
+ Copyright (C) 1991 Free Software Foundation, Inc.
+                    51 Franklin Street - Fifth Floor
+                    Boston, MA 02110-1301, USA.
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+[This is the first released version of the library GPL.  It is
+ numbered 2 because it goes with version 2 of the ordinary GPL.]
+
+			    Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+Licenses are intended to guarantee your freedom to share and change
+free software--to make sure the software is free for all its users.
+
+  This license, the Library General Public License, applies to some
+specially designated Free Software Foundation software, and to any
+other libraries whose authors decide to use it.  You can use it for
+your libraries, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if
+you distribute copies of the library, or if you modify it.
+
+  For example, if you distribute copies of the library, whether gratis
+or for a fee, you must give the recipients all the rights that we gave
+you.  You must make sure that they, too, receive or can get the source
+code.  If you link a program with the library, you must provide
+complete object files to the recipients so that they can relink them
+with the library, after making changes to the library and recompiling
+it.  And you must show them these terms so they know their rights.
+
+  Our method of protecting your rights has two steps: (1) copyright
+the library, and (2) offer you this license which gives you legal
+permission to copy, distribute and/or modify the library.
+
+  Also, for each distributor's protection, we want to make certain
+that everyone understands that there is no warranty for this free
+library.  If the library is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original
+version, so that any problems introduced by others will not reflect on
+the original authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that companies distributing free
+software will individually obtain patent licenses, thus in effect
+transforming the program into proprietary software.  To prevent this,
+we have made it clear that any patent must be licensed for everyone's
+free use or not licensed at all.
+
+  Most GNU software, including some libraries, is covered by the ordinary
+GNU General Public License, which was designed for utility programs.  This
+license, the GNU Library General Public License, applies to certain
+designated libraries.  This license is quite different from the ordinary
+one; be sure to read it in full, and don't assume that anything in it is
+the same as in the ordinary license.
+
+  The reason we have a separate public license for some libraries is that
+they blur the distinction we usually make between modifying or adding to a
+program and simply using it.  Linking a program with a library, without
+changing the library, is in some sense simply using the library, and is
+analogous to running a utility program or application program.  However, in
+a textual and legal sense, the linked executable is a combined work, a
+derivative of the original library, and the ordinary General Public License
+treats it as such.
+
+  Because of this blurred distinction, using the ordinary General
+Public License for libraries did not effectively promote software
+sharing, because most developers did not use the libraries.  We
+concluded that weaker conditions might promote sharing better.
+
+  However, unrestricted linking of non-free programs would deprive the
+users of those programs of all benefit from the free status of the
+libraries themselves.  This Library General Public License is intended to
+permit developers of non-free programs to use free libraries, while
+preserving your freedom as a user of such programs to change the free
+libraries that are incorporated in them.  (We have not seen how to achieve
+this as regards changes in header files, but we have achieved it as regards
+changes in the actual functions of the Library.)  The hope is that this
+will lead to faster development of free libraries.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.  Pay close attention to the difference between a
+"work based on the library" and a "work that uses the library".  The
+former contains code derived from the library, while the latter only
+works together with the library.
+
+  Note that it is possible for a library to be covered by the ordinary
+General Public License rather than by this special one.
+
+		  GNU LIBRARY GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License Agreement applies to any software library which
+contains a notice placed by the copyright holder or other authorized
+party saying it may be distributed under the terms of this Library
+General Public License (also called "this License").  Each licensee is
+addressed as "you".
+
+  A "library" means a collection of software functions and/or data
+prepared so as to be conveniently linked with application programs
+(which use some of those functions and data) to form executables.
+
+  The "Library", below, refers to any such software library or work
+which has been distributed under these terms.  A "work based on the
+Library" means either the Library or any derivative work under
+copyright law: that is to say, a work containing the Library or a
+portion of it, either verbatim or with modifications and/or translated
+straightforwardly into another language.  (Hereinafter, translation is
+included without limitation in the term "modification".)
+
+  "Source code" for a work means the preferred form of the work for
+making modifications to it.  For a library, complete source code means
+all the source code for all modules it contains, plus any associated
+interface definition files, plus the scripts used to control compilation
+and installation of the library.
+
+  Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running a program using the Library is not restricted, and output from
+such a program is covered only if its contents constitute a work based
+on the Library (independent of the use of the Library in a tool for
+writing it).  Whether that is true depends on what the Library does
+and what the program that uses the Library does.
+  
+  1. You may copy and distribute verbatim copies of the Library's
+complete source code as you receive it, in any medium, provided that
+you conspicuously and appropriately publish on each copy an
+appropriate copyright notice and disclaimer of warranty; keep intact
+all the notices that refer to this License and to the absence of any
+warranty; and distribute a copy of this License along with the
+Library.
+
+  You may charge a fee for the physical act of transferring a copy,
+and you may at your option offer warranty protection in exchange for a
+fee.
+
+  2. You may modify your copy or copies of the Library or any portion
+of it, thus forming a work based on the Library, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) The modified work must itself be a software library.
+
+    b) You must cause the files modified to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    c) You must cause the whole of the work to be licensed at no
+    charge to all third parties under the terms of this License.
+
+    d) If a facility in the modified Library refers to a function or a
+    table of data to be supplied by an application program that uses
+    the facility, other than as an argument passed when the facility
+    is invoked, then you must make a good faith effort to ensure that,
+    in the event an application does not supply such function or
+    table, the facility still operates, and performs whatever part of
+    its purpose remains meaningful.
+
+    (For example, a function in a library to compute square roots has
+    a purpose that is entirely well-defined independent of the
+    application.  Therefore, Subsection 2d requires that any
+    application-supplied function or table used by this function must
+    be optional: if the application does not supply it, the square
+    root function must still compute square roots.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Library,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Library, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote
+it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Library.
+
+In addition, mere aggregation of another work not based on the Library
+with the Library (or with a work based on the Library) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may opt to apply the terms of the ordinary GNU General Public
+License instead of this License to a given copy of the Library.  To do
+this, you must alter all the notices that refer to this License, so
+that they refer to the ordinary GNU General Public License, version 2,
+instead of to this License.  (If a newer version than version 2 of the
+ordinary GNU General Public License has appeared, then you can specify
+that version instead if you wish.)  Do not make any other change in
+these notices.
+
+  Once this change is made in a given copy, it is irreversible for
+that copy, so the ordinary GNU General Public License applies to all
+subsequent copies and derivative works made from that copy.
+
+  This option is useful when you wish to copy part of the code of
+the Library into a program that is not a library.
+
+  4. You may copy and distribute the Library (or a portion or
+derivative of it, under Section 2) in object code or executable form
+under the terms of Sections 1 and 2 above provided that you accompany
+it with the complete corresponding machine-readable source code, which
+must be distributed under the terms of Sections 1 and 2 above on a
+medium customarily used for software interchange.
+
+  If distribution of object code is made by offering access to copy
+from a designated place, then offering equivalent access to copy the
+source code from the same place satisfies the requirement to
+distribute the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  5. A program that contains no derivative of any portion of the
+Library, but is designed to work with the Library by being compiled or
+linked with it, is called a "work that uses the Library".  Such a
+work, in isolation, is not a derivative work of the Library, and
+therefore falls outside the scope of this License.
+
+  However, linking a "work that uses the Library" with the Library
+creates an executable that is a derivative of the Library (because it
+contains portions of the Library), rather than a "work that uses the
+library".  The executable is therefore covered by this License.
+Section 6 states terms for distribution of such executables.
+
+  When a "work that uses the Library" uses material from a header file
+that is part of the Library, the object code for the work may be a
+derivative work of the Library even though the source code is not.
+Whether this is true is especially significant if the work can be
+linked without the Library, or if the work is itself a library.  The
+threshold for this to be true is not precisely defined by law.
+
+  If such an object file uses only numerical parameters, data
+structure layouts and accessors, and small macros and small inline
+functions (ten lines or less in length), then the use of the object
+file is unrestricted, regardless of whether it is legally a derivative
+work.  (Executables containing this object code plus portions of the
+Library will still fall under Section 6.)
+
+  Otherwise, if the work is a derivative of the Library, you may
+distribute the object code for the work under the terms of Section 6.
+Any executables containing that work also fall under Section 6,
+whether or not they are linked directly with the Library itself.
+
+  6. As an exception to the Sections above, you may also compile or
+link a "work that uses the Library" with the Library to produce a
+work containing portions of the Library, and distribute that work
+under terms of your choice, provided that the terms permit
+modification of the work for the customer's own use and reverse
+engineering for debugging such modifications.
+
+  You must give prominent notice with each copy of the work that the
+Library is used in it and that the Library and its use are covered by
+this License.  You must supply a copy of this License.  If the work
+during execution displays copyright notices, you must include the
+copyright notice for the Library among them, as well as a reference
+directing the user to the copy of this License.  Also, you must do one
+of these things:
+
+    a) Accompany the work with the complete corresponding
+    machine-readable source code for the Library including whatever
+    changes were used in the work (which must be distributed under
+    Sections 1 and 2 above); and, if the work is an executable linked
+    with the Library, with the complete machine-readable "work that
+    uses the Library", as object code and/or source code, so that the
+    user can modify the Library and then relink to produce a modified
+    executable containing the modified Library.  (It is understood
+    that the user who changes the contents of definitions files in the
+    Library will not necessarily be able to recompile the application
+    to use the modified definitions.)
+
+    b) Accompany the work with a written offer, valid for at
+    least three years, to give the same user the materials
+    specified in Subsection 6a, above, for a charge no more
+    than the cost of performing this distribution.
+
+    c) If distribution of the work is made by offering access to copy
+    from a designated place, offer equivalent access to copy the above
+    specified materials from the same place.
+
+    d) Verify that the user has already received a copy of these
+    materials or that you have already sent this user a copy.
+
+  For an executable, the required form of the "work that uses the
+Library" must include any data and utility programs needed for
+reproducing the executable from it.  However, as a special exception,
+the source code distributed need not include anything that is normally
+distributed (in either source or binary form) with the major
+components (compiler, kernel, and so on) of the operating system on
+which the executable runs, unless that component itself accompanies
+the executable.
+
+  It may happen that this requirement contradicts the license
+restrictions of other proprietary libraries that do not normally
+accompany the operating system.  Such a contradiction means you cannot
+use both them and the Library together in an executable that you
+distribute.
+
+  7. You may place library facilities that are a work based on the
+Library side-by-side in a single library together with other library
+facilities not covered by this License, and distribute such a combined
+library, provided that the separate distribution of the work based on
+the Library and of the other library facilities is otherwise
+permitted, and provided that you do these two things:
+
+    a) Accompany the combined library with a copy of the same work
+    based on the Library, uncombined with any other library
+    facilities.  This must be distributed under the terms of the
+    Sections above.
+
+    b) Give prominent notice with the combined library of the fact
+    that part of it is a work based on the Library, and explaining
+    where to find the accompanying uncombined form of the same work.
+
+  8. You may not copy, modify, sublicense, link with, or distribute
+the Library except as expressly provided under this License.  Any
+attempt otherwise to copy, modify, sublicense, link with, or
+distribute the Library is void, and will automatically terminate your
+rights under this License.  However, parties who have received copies,
+or rights, from you under this License will not have their licenses
+terminated so long as such parties remain in full compliance.
+
+  9. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Library or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Library (or any work based on the
+Library), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Library or works based on it.
+
+  10. Each time you redistribute the Library (or any work based on the
+Library), the recipient automatically receives a license from the
+original licensor to copy, distribute, link with or modify the Library
+subject to these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  11. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Library at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Library by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Library.
+
+If any portion of this section is held invalid or unenforceable under any
+particular circumstance, the balance of the section is intended to apply,
+and the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  12. If the distribution and/or use of the Library is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Library under this License may add
+an explicit geographical distribution limitation excluding those countries,
+so that distribution is permitted only in or among countries not thus
+excluded.  In such case, this License incorporates the limitation as if
+written in the body of this License.
+
+  13. The Free Software Foundation may publish revised and/or new
+versions of the Library General Public License from time to time.
+Such new versions will be similar in spirit to the present version,
+but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Library
+specifies a version number of this License which applies to it and
+"any later version", you have the option of following the terms and
+conditions either of that version or of any later version published by
+the Free Software Foundation.  If the Library does not specify a
+license version number, you may choose any version ever published by
+the Free Software Foundation.
+
+  14. If you wish to incorporate parts of the Library into other free
+programs whose distribution conditions are incompatible with these,
+write to the author to ask for permission.  For software which is
+copyrighted by the Free Software Foundation, write to the Free
+Software Foundation; we sometimes make exceptions for this.  Our
+decision will be guided by the two goals of preserving the free status
+of all derivatives of our free software and of promoting the sharing
+and reuse of software generally.
+
+			    NO WARRANTY
+
+  15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO
+WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW.
+EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR
+OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY
+KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE
+LIBRARY IS WITH YOU.  SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME
+THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
+WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY
+AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU
+FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR
+CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE
+LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING
+RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
+FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF
+SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGES.
+
+		     END OF TERMS AND CONDITIONS
+          How to Apply These Terms to Your New Libraries
+
+  If you develop a new library, and you want it to be of the greatest
+possible use to the public, we recommend making it free software that
+everyone can redistribute and change.  You can do so by permitting
+redistribution under these terms (or, alternatively, under the terms of the
+ordinary General Public License).
+
+  To apply these terms, attach the following notices to the library.  It is
+safest to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least the
+"copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the library's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+Also add information on how to contact you by electronic and paper mail.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the library, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the
+  library `Frob' (a library for tweaking knobs) written by James Random Hacker.
+
+  <signature of Ty Coon>, 1 April 1990
+  Ty Coon, President of Vice
+
+That's all there is to it!

--- a/README.md
+++ b/README.md
@@ -60,7 +60,16 @@ importer addon (available for [2.80](https://gist.github.com/yorikvanhavre/68015
 [2.79](https://gist.github.com/yorikvanhavre/e873d51c8f0e307e333fe595c429ba87)). Importing your FreeCAD file in Blender before 
 rendering gives you a lot more options such as placing lights and textures.
 
-## To Do
+
+
+## Contributing
+
+Any contributions are welcome! Feel free to post PR to this project.
+
+### Code of Conduct
+This project is covered by FreeCAD [Code of Conduct](https://github.com/FreeCAD/FreeCAD/blob/master/CODE_OF_CONDUCT.md).
+
+### To Do (not exhaustive)
 
 * Currently the external (open the file to be rendered in the Renderer's GUI)/internal (render directly inside FreeCAD) render 
 mode is not implemented, the external mode will always be used.
@@ -68,11 +77,17 @@ mode is not implemented, the external mode will always be used.
 * Add support for Blender's Eevee
 * Add support for OpenCasCade's [CadRays](https://www.opencascade.com/content/cadrays) 
 
+### Notes on Code Quality
+
+In order to make this module easy to read, maintain and extend by everyone, we strive to sustain a good level of code quality.
+In particular, we try to ensure that the code complies with PEP8 / PEP257. Therefore,
+* If you post contributions (thank you very much!), please enforce PEP8 / PEP257 on your production, and run pylint and flake8 before sending PR. A specific pylintrc file, with general PEP8 rules and some specific tweaks related to FreeCAD framework, is provided for that purpose in the project directory.
+* If you see anything that could be improved in terms of code quality (PEP compliance, pythonicity, coding best practices...), or simply readability (comments, documentation...), do not hesitate to post propositions!
+
+
 ## Feedback
 
 For Feedback, bugs, feature requests, and further discussion please use the dedicated FreeCAD [forum thread]()
 
 ## Author
 Yorik Can Havre AKA [@yorikvanhavre](https://github.com/yorikvanhavre) ([blog](https://yorik.uncreated.net/))
-
-## License

--- a/camera.py
+++ b/camera.py
@@ -1,24 +1,24 @@
-#***************************************************************************
-#*                                                                         *
-#*   Copyright (c) 2020 Howetuft <howetuft@gmail.com>                      *
-#*                                                                         *
-#*   This program is free software; you can redistribute it and/or modify  *
-#*   it under the terms of the GNU Lesser General Public License (LGPL)    *
-#*   as published by the Free Software Foundation; either version 2 of     *
-#*   the License, or (at your option) any later version.                   *
-#*   for detail see the LICENCE text file.                                 *
-#*                                                                         *
-#*   This program is distributed in the hope that it will be useful,       *
-#*   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
-#*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
-#*   GNU Library General Public License for more details.                  *
-#*                                                                         *
-#*   You should have received a copy of the GNU Library General Public     *
-#*   License along with this program; if not, write to the Free Software   *
-#*   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
-#*   USA                                                                   *
-#*                                                                         *
-#***************************************************************************
+# ***************************************************************************
+# *                                                                         *
+# *   Copyright (c) 2020 Howetuft <howetuft@gmail.com>                      *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   This program is distributed in the hope that it will be useful,       *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with this program; if not, write to the Free Software   *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
 
 """This module implements a Camera object, which allows to take a snapshot
 of Coin Camera settings and use them later for rendering"""
@@ -27,67 +27,60 @@ from collections import namedtuple
 from math import degrees, radians
 import shlex
 
+from pivy import coin
 from PySide.QtGui import QAction
 from PySide.QtCore import QT_TRANSLATE_NOOP, QObject, SIGNAL
-from pivy import coin
-
-import FreeCAD
-import FreeCADGui
+import FreeCAD as App
+import FreeCADGui as Gui
 import Part
 
-# ===========================================================================
-
-def create_camera():
-    """Create a Camera object in active document"""
-
-    fpo = FreeCAD.ActiveDocument.addObject("Part::FeaturePython", "Camera")
-    Camera(fpo)
-    viewp = ViewProviderCamera(fpo.ViewObject)
-    if FreeCAD.GuiUp:
-        viewp.set_camera_from_gui()
-    FreeCAD.ActiveDocument.recompute()
-    return fpo
 
 # ===========================================================================
+
 
 class Camera:
-
     """A camera for rendering.
 
-This object allows to record camera settings from the Coin camera, and to reuse them
-for rendering.
+    This object allows to record camera settings from the Coin camera, and to
+    reuse them for rendering.
 
-Camera Orientation is defined by a Rotation Axis and a Rotation Angle, applied to
-'default camera'.
-Default camera looks from (0,0,1) towards the origin, and the up direction
-is (0,1,0).
+    Camera Orientation is defined by a Rotation Axis and a Rotation Angle,
+    applied to 'default camera'.
+    Default camera looks from (0,0,1) towards the origin, and the up direction
+    is (0,1,0).
 
-For more information, see Coin documentation, Camera section.
-(https://developer.openinventor.com/UserGuides/Oiv9/Inventor_Mentor/\
-Cameras_and_Lights/Cameras.html)
+    For more information, see Coin documentation, Camera section.
+    <https://developer.openinventor.com/UserGuides/Oiv9/Inventor_Mentor/Cameras_and_Lights/Cameras.html>
     """
 
-    # Enumeration of allowed values for ViewportMapping parameter (see Coin documentation)
-    # Nota: Keep following tuple in original order, as relationship between values and
-    # indexes matters and is used for reverse transcoding
-    VIEWPORTMAPPINGENUM = ("CROP_VIEWPORT_FILL_FRAME", "CROP_VIEWPORT_LINE_FRAME",
-                           "CROP_VIEWPORT_NO_FRAME", "ADJUST_CAMERA", "LEAVE_ALONE")
+    # Enumeration of allowed values for ViewportMapping parameter (see Coin
+    # documentation)
+    # Nota: Keep following tuple in original order, as relationship between
+    # values and indexes matters and is used for reverse transcoding
+    VIEWPORTMAPPINGENUM = ("CROP_VIEWPORT_FILL_FRAME",
+                           "CROP_VIEWPORT_LINE_FRAME",
+                           "CROP_VIEWPORT_NO_FRAME",
+                           "ADJUST_CAMERA",
+                           "LEAVE_ALONE")
 
     Prop = namedtuple('Prop', ['Type', 'Group', 'Doc', 'Default'])
 
-    # PythonFeature object properties
+    # FeaturePython object properties
     PROPERTIES = {
         "Projection": Prop(
             "App::PropertyEnumeration",
             "Camera",
-            QT_TRANSLATE_NOOP("Render", "Type of projection: Perspective/Orthographic"),
+            QT_TRANSLATE_NOOP("Render",
+                              "Type of projection: Perspective/Orthographic"),
             ("Perspective", "Orthographic")),
 
         "Placement": Prop(
             "App::PropertyPlacement",
             "",
             QT_TRANSLATE_NOOP("Render", "Placement of camera"),
-            FreeCAD.Placement(FreeCAD.Vector(0, 0, 0), FreeCAD.Vector(0, 0, 1), 0)),
+            App.Placement(App.Vector(0, 0, 0),
+                          App.Vector(0, 0, 1),
+                          0)),
 
         "ViewportMapping": Prop(
             "App::PropertyEnumeration",
@@ -128,7 +121,8 @@ Cameras_and_Lights/Cameras.html)
         "HeightAngle": Prop(
             "App::PropertyAngle",
             "Camera",
-            QT_TRANSLATE_NOOP("Render", "Height angle, for perspective camera"),
+            QT_TRANSLATE_NOOP("Render",
+                              "Height angle, for perspective camera"),
             60),
 
         "Shape": Prop(
@@ -138,20 +132,18 @@ Cameras_and_Lights/Cameras.html)
             None),
 
     }
-    # ~PythonFeature object properties
+    # ~FeaturePython object properties
 
     @classmethod
     def set_properties(cls, fpo):
-        """Set underlying PythonFeature object's properties"""
+        """Set underlying FeaturePython object's properties"""
         for name in cls.PROPERTIES.keys() - set(fpo.PropertiesList):
-            fields = cls.PROPERTIES[name]
-            prop = fpo.addProperty(fields.Type, name, fields.Group, fields.Doc, 0)
-            setattr(prop, name, fields.Default)
-
+            spec = cls.PROPERTIES[name]
+            prop = fpo.addProperty(spec.Type, name, spec.Group, spec.Doc, 0)
+            setattr(prop, name, spec.Default)
 
     def __init__(self, fpo):
-        """
-        Camera Initializer
+        """Camera Initializer
 
         Arguments
         ---------
@@ -161,6 +153,38 @@ Cameras_and_Lights/Cameras.html)
         fpo.Proxy = self
         self.set_properties(fpo)
 
+    @staticmethod
+    def create(document=None):
+        """Create a Camera object in a document
+
+        Factory method to create a new camera object.
+        The camera is created into the active document (default).
+        Optionally, it is possible to specify a target document, in that case
+        the camera is created in the given document.
+
+        If Gui is up, the camera is initialized to current active camera;
+        otherwise it is set to DEFAULT_CAMERA_STRING.
+        This method also create the FeaturePython and the ViewProviderCamera
+        related objects.
+
+        Params:
+        document: the document where to create camera (optional)
+
+        Returns:
+        The newly created Camera object, the FeaturePython object and the
+        ViewProviderCamera object"""
+
+        doc = document if document else App.ActiveDocument
+        fpo = doc.addObject("Part::FeaturePython", "Camera")
+        cam = Camera(fpo)
+        viewp = ViewProviderCamera(fpo.ViewObject)
+        if App.GuiUp:
+            viewp.set_camera_from_gui()
+        else:
+            set_cam_from_coin_string(fpo, DEFAULT_CAMERA_STRING)
+        App.ActiveDocument.recompute()
+        return cam, fpo, viewp
+
     def onDocumentRestored(self, fpo):
         """Callback triggered when document is restored"""
         self.type = "Camera"
@@ -168,6 +192,7 @@ Cameras_and_Lights/Cameras.html)
         self.set_properties(fpo)
 
     def execute(self, fpo):
+        # pylint: disable=no-self-use
         """Callback triggered on document recomputation (mandatory).
         It mainly draws the camera graphical representation"""
 
@@ -206,41 +231,54 @@ class ViewProviderCamera:
 
     def __init__(self, vobj):
         vobj.Proxy = self
-        self.fpo = vobj.Object # Related FeaturePython object
+        self.fpo = vobj.Object  # Related FeaturePython object
 
     def attach(self, vobj):
-        """Callback triggered when object is created/restored"""
+        """Code executed when object is created/restored (callback)"""
         self.fpo = vobj.Object
 
     def getDisplayModes(self, _):
-        """Return a list of display modes"""
+        # pylint: disable=no-self-use
+        """Return a list of display modes (callback)"""
         return ["Shaded"]
 
     def getDefaultDisplayMode(self):
-        """Return the name of the default display mode.  It must be defined in
-        getDisplayModes."""
+        # pylint: disable=no-self-use
+        """Return the name of the default display mode (callback)
+
+        The returned mode must be defined in getDisplayModes.
+        """
         return "Shaded"
 
     def setDisplayMode(self, mode):
-        """Map the display mode defined in attach with those defined in getDisplayModes.
+        # pylint: disable=no-self-use
+        """Map the display mode defined in attach with those defined in
+        getDisplayModes (callback)
+
         Since they have the same names nothing needs to be done.
-        This method is optional."""
+        This method is optional.
+        """
         return mode
 
     def getIcon(self):
-        """Return the icon which will appear in the tree view."""
+        # pylint: disable=no-self-use
+        """Return the icon which will appear in the tree view (callback)"""
         return ":/icons/camera-photo.svg"
 
     def setupContextMenu(self, vobj, menu):
-        """Setup the context menu associated to the object in tree view"""
-        action1 = QAction(QT_TRANSLATE_NOOP("Render", "Set GUI to this camera"),
+        """Setup the context menu associated to the object in tree view
+        (callback)
+        """
+        action1 = QAction(QT_TRANSLATE_NOOP("Render",
+                                            "Set GUI to this camera"),
                           menu)
         QObject.connect(action1,
                         SIGNAL("triggered()"),
                         self.set_gui_from_camera)
         menu.addAction(action1)
 
-        action2 = QAction(QT_TRANSLATE_NOOP("Render", "Set this camera to GUI"),
+        action2 = QAction(QT_TRANSLATE_NOOP("Render",
+                                            "Set this camera to GUI"),
                           menu)
         QObject.connect(action2,
                         SIGNAL("triggered()"),
@@ -248,17 +286,16 @@ class ViewProviderCamera:
         menu.addAction(action2)
 
     def updateData(self, fpo, prop):
-        """Callback triggered when properties are modified"""
+        # pylint: disable=no-self-use
+        """Code executed when properties are modified (callback)"""
         return
 
     def set_camera_from_gui(self):
         """Set this camera from GUI camera"""
 
-        assert FreeCAD.GuiUp, "Cannot set camera from GUI: GUI is down"
-
+        assert App.GuiUp, "Cannot set camera from GUI: GUI is down"
         fpo = self.fpo
-        node = FreeCADGui.ActiveDocument.ActiveView.getCameraNode()
-
+        node = Gui.ActiveDocument.ActiveView.getCameraNode()
         typ = node.getTypeId()
         if typ == coin.SoPerspectiveCamera.getClassTypeId():
             fpo.Projection = "Perspective"
@@ -269,26 +306,27 @@ class ViewProviderCamera:
         else:
             raise ValueError("Unknown camera type")
 
-        pos = FreeCAD.Vector(node.position.getValue())
-        rot = FreeCAD.Rotation(*node.orientation.getValue().getValue())
-        fpo.Placement = FreeCAD.Placement(pos, rot)
+        pos = App.Vector(node.position.getValue())
+        rot = App.Rotation(*node.orientation.getValue().getValue())
+        fpo.Placement = App.Placement(pos, rot)
 
         fpo.NearDistance = float(node.nearDistance.getValue())
         fpo.FarDistance = float(node.farDistance.getValue())
         fpo.FocalDistance = float(node.focalDistance.getValue())
         fpo.AspectRatio = float(node.aspectRatio.getValue())
-        fpo.ViewportMapping = Camera.VIEWPORTMAPPINGENUM[node.viewportMapping.getValue()]
+        index = node.viewportMapping.getValue()
+        fpo.ViewportMapping = Camera.VIEWPORTMAPPINGENUM[index]
 
     def set_gui_from_camera(self):
         """Set GUI camera to this camera"""
 
-        assert FreeCAD.GuiUp, "Cannot set GUI from camera: GUI is down"
+        assert App.GuiUp, "Cannot set GUI from camera: GUI is down"
 
         fpo = self.fpo
 
-        FreeCADGui.ActiveDocument.ActiveView.setCameraType(fpo.Projection)
+        Gui.ActiveDocument.ActiveView.setCameraType(fpo.Projection)
 
-        node = FreeCADGui.ActiveDocument.ActiveView.getCameraNode()
+        node = Gui.ActiveDocument.ActiveView.getCameraNode()
 
         node.position.setValue(fpo.Placement.Base)
         rot = fpo.Placement.Rotation
@@ -315,14 +353,14 @@ class ViewProviderCamera:
         return None
 
 
-
 # ===========================================================================
 
 
 def set_cam_from_coin_string(cam, camstr):
-    """Set a Camera object from a string containing a camera description in Open Inventor
-    format
+    """Set a Camera object from a string containing a camera description in
+    Open Inventor format
 
+    cam: a Camera FeaturePython object
     camstr: a string in OpenInventor format, ex:
     #Inventor V2.1 ascii
 
@@ -353,21 +391,22 @@ def set_cam_from_coin_string(cam, camstr):
      focalDistance 5
      height 4.1421356
 
-    }"""
+    }
+    """
 
     # Split, clean and tokenize
-    camdata = [y for y in [shlex.split(x, comments=True)\
-                            for x in camstr.split('\n')] if y]
-    camdict = {y[0]:y[1:] for y in camdata}
+    camdata = [y for y in [shlex.split(x, comments=True)
+                           for x in camstr.split('\n')] if y]
+    camdict = {y[0]: y[1:] for y in camdata}
 
-    cam.Projection = camdata[0][0][0:-6] # Data block should start with Cam Type...
+    cam.Projection = camdata[0][0][0:-6]  # Data should start with Cam Type...
     assert cam.Projection in ('Perspective', 'Orthographic'),\
         "Invalid camera header in camera string"
     try:
-        pos = FreeCAD.Vector(camdict["position"][0:3])
-        rot = FreeCAD.Rotation(FreeCAD.Vector(camdict["orientation"][0:3]),
-                               degrees(float(camdict["orientation"][3])))
-        cam.Placement = FreeCAD.Placement(pos, rot)
+        pos = App.Vector(camdict["position"][0:3])
+        rot = App.Rotation(App.Vector(camdict["orientation"][0:3]),
+                           degrees(float(camdict["orientation"][3])))
+        cam.Placement = App.Placement(pos, rot)
         cam.FocalDistance = float(camdict["focalDistance"][0])
         cam.AspectRatio = float(camdict["aspectRatio"][0])
         cam.ViewportMapping = str(camdict["viewportMapping"][0])
@@ -398,7 +437,7 @@ def get_coin_string_from_cam(cam):
     def check_enum(field):
         """Check if the enum field value is valid"""
         assert getattr(cam, field) in Camera.PROPERTIES[field].Default,\
-                "Invalid %s value" %field
+            "Invalid %s value" % field
 
     check_enum("Projection")
     check_enum("ViewportMapping")
@@ -421,10 +460,27 @@ def get_coin_string_from_cam(cam):
     res.append("}\n")
     return '\n'.join(res)
 
+
 def retrieve_legacy_camera(project):
-    """For backward compatibility: Retrieve legacy camera information in rendering projects
-    and transform it into Camera object"""
+    """For backward compatibility: Retrieve legacy camera information in
+    rendering projects and transform it into Camera object
+    """
     assert isinstance(project.Camera, str),\
-        "Project's Camera property should contain a string"""
-    fpo = create_camera()
+        "Project's Camera property should contain a string"
+    _, fpo, _ = Camera.create()
     set_cam_from_coin_string(fpo, project.Camera)
+
+
+# A default camera...
+DEFAULT_CAMERA_STRING = """\
+#Inventor V2.1 ascii
+
+OrthographicCamera {
+  viewportMapping ADJUST_CAMERA
+  position -0 -0 100
+  orientation 0 0 1  0
+  aspectRatio 1
+  focalDistance 100
+  height 100
+}
+"""

--- a/pylintrc
+++ b/pylintrc
@@ -1,0 +1,403 @@
+[MASTER]
+
+# Specify a configuration file.
+#rcfile=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+init-hook='import sys; sys.path.append("/usr/lib/freecad/lib"); sys.path.append("/usr/lib/freecad/Mod"); sys.path.append("C:\\Program Files\\FreeCAD 0.18\\bin"); sys.path.append("C:\\Program Files\\FreeCAD 0.18\\Mod")'
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=CVS
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+load-plugins=
+    pylint.extensions.check_elif
+
+# Use multiple processes to speed up Pylint.
+jobs=2
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code
+extension-pkg-whitelist=PySide2,
+                        PySide,
+                        FreeCAD,
+                        FreeCADGui,
+                        Part,
+                        Draft,
+                        ImageGui,
+                        MeshPart
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED
+confidence=
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time. See also the "--disable" option for examples.
+enable=use-symbolic-message-instead,useless-supression,fixme
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once).You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use"--disable=all --enable=classes
+# --disable=W"
+
+disable=suppressed-message
+
+
+[REPORTS]
+
+# Set the output format. Available formats are text, parseable, colorized, msvs
+# (visual studio) and html. You can also give a reporter class, eg
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Put messages in a separate file for each module / package specified on the
+# command line instead of printing them on stdout. Reports (if any) will be
+# written in a file name "pylint_global.[txt|html]".
+files-output=no
+
+# Tells whether to display a full report or only the messages
+reports=no
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details
+#msg-template=
+
+
+[LOGGING]
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format
+logging-modules=logging
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,XXX,TODO
+
+
+[SIMILARITIES]
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+
+[VARIABLES]
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# A regular expression matching the name of dummy variables (i.e. expectedly
+# not used).
+dummy-variables-rgx=_$|dummy
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid defining new builtins when possible.
+additional-builtins=
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+# Note: here we list all FreeCAD framework callbacks methods, plus external
+# renderers expected methods
+callbacks=GetResources,
+          Activated,
+          onDocumentRestored,
+          onChanged,
+          getDisplayModes,
+          getDefaultDisplayMode,
+          setDisplayMode,
+          isShow,
+          getIcon,
+          setupContextMenu,
+          claimChildren,
+          execute,
+          attach,
+          updateData,
+          render,
+          write_camera,
+          write_object,
+          write_pointlight
+
+
+[FORMAT]
+
+# Maximum number of characters on a single line.
+max-line-length=79  # PEP8. Yes, it'short, but "dura lex sed lex"
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+# List of optional constructs for which whitespace checking is disabled
+no-space-check=trailing-comma,dict-separator
+
+# Maximum number of lines in a module
+max-module-lines=2000
+
+# String used as indentation unit. This is usually " " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Number of spaces of indent required inside a hanging or continued line.
+indent-after-paren=4
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+
+[BASIC]
+
+# List of builtins function names that should not be used, separated by a comma
+bad-functions=map,filter,input
+
+# Good variable names which should always be accepted, separated by a comma
+good-names=i,j,k,ex,Run,_,f
+
+# Bad variable names which should always be refused, separated by a comma
+bad-names=foo,bar,baz,toto,tutu,tata
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Include a hint for the correct naming format with invalid-name
+include-naming-hint=yes
+
+# Regular expression matching correct function names
+function-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for function names
+function-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct variable names
+variable-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for variable names
+variable-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct constant names
+const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__))$
+
+# Naming hint for constant names
+const-name-hint=(([A-Z_][A-Z0-9_]*)|(__.*__))$
+
+# Regular expression matching correct attribute names
+attr-rgx=[a-z_][a-z0-9_]{2,}$
+
+# Naming hint for attribute names
+attr-name-hint=[a-z_][a-z0-9_]{2,}$
+
+# Regular expression matching correct argument names
+argument-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for argument names
+argument-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct class attribute names
+class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
+
+# Naming hint for class attribute names
+class-attribute-name-hint=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
+
+# Regular expression matching correct inline iteration names
+inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
+
+# Naming hint for inline iteration names
+inlinevar-name-hint=[A-Za-z_][A-Za-z0-9_]*$
+
+# Regular expression matching correct class names
+class-rgx=[A-Z_][a-zA-Z0-9]+$
+
+# Naming hint for class names
+class-name-hint=[A-Z_][a-zA-Z0-9]+$
+
+# Regular expression matching correct module names
+module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+
+# Naming hint for module names
+module-name-hint=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+
+# Regular expression matching correct method names
+method-rgx=([a-z_][a-z0-9_]{2,}$|GetResources|Activated|onDocumentRestored|onChanged|getDisplayModes|getDefaultDisplayMode|setDisplayMode|isShow|getIcon|setupContextMenu|claimChildren|Initialize|GetClassName|updateData)
+
+# Naming hint for method names
+method-name-hint=[a-z_][a-z0-9_]{2,}$
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=__.*__
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# List of decorators that define properties, such as abc.abstractproperty.
+property-classes=abc.abstractproperty
+
+
+[TYPECHECK]
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis
+ignored-modules=FreeCADGui
+
+# List of classes names for which member attributes should not be checked
+# (useful for classes with attributes dynamically set).
+ignored-classes=SQLObject,
+                optparse.Values,
+                thread._local,
+                _thread._local,
+                module
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=REQUEST,
+                  acl_users,
+                  aq_parent,
+                  App_Console.PrintError,
+                  App_Console.PrintLog,
+                  App_Console.PrintMessage,
+                  Console.PrintError,
+                  Console.PrintLog,
+                  Console.PrintMessage
+
+# List of decorators that create context managers from functions, such as
+# contextlib.contextmanager.
+contextmanager-decorators=contextlib.contextmanager
+
+
+[SPELLING]
+
+# Spelling dictionary name. Available dictionaries: none. To make it working
+# install python-enchant package.
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to indicated private dictionary in
+# --spelling-private-dict-file option instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method
+max-args=10
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore
+ignored-argument-names=_.*
+
+# Maximum number of locals for function / method body
+max-locals=25
+
+# Maximum number of return / yield for function / method body
+max-returns=11
+
+# Maximum number of branch for function / method body
+max-branches=26
+
+# Maximum number of statements in function / method body
+max-statements=100
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=11
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=25
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,__new__,setUp,__post_init__
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=mcs
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,_fields,_replace,_source,_make
+
+
+[IMPORTS]
+
+# Deprecated modules which should not be used, separated by a comma
+deprecated-modules=regsub,TERMIOS,Bastion,rexec
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled)
+import-graph=
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled)
+ext-import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled)
+int-import-graph=
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "Exception"
+overgeneral-exceptions=Exception

--- a/renderers/Appleseed.py
+++ b/renderers/Appleseed.py
@@ -1,212 +1,224 @@
-from __future__ import print_function
-#***************************************************************************
-#*                                                                         *
-#*   Copyright (c) 2017 Yorik van Havre <yorik@uncreated.net>              *
-#*                                                                         *
-#*   This program is free software; you can redistribute it and/or modify  *
-#*   it under the terms of the GNU Lesser General Public License (LGPL)    *
-#*   as published by the Free Software Foundation; either version 2 of     *
-#*   the License, or (at your option) any later version.                   *
-#*   for detail see the LICENCE text file.                                 *
-#*                                                                         *
-#*   This program is distributed in the hope that it will be useful,       *
-#*   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
-#*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
-#*   GNU Library General Public License for more details.                  *
-#*                                                                         *
-#*   You should have received a copy of the GNU Library General Public     *
-#*   License along with this program; if not, write to the Free Software   *
-#*   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
-#*   USA                                                                   *
-#*                                                                         *
-#***************************************************************************
+# ***************************************************************************
+# *                                                                         *
+# *   Copyright (c) 2017 Yorik van Havre <yorik@uncreated.net>              *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   This program is distributed in the hope that it will be useful,       *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with this program; if not, write to the Free Software   *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
 
-# Appleseed renderer for FreeCAD
+"""Appleseed renderer for FreeCAD"""
 
 # This file can also be used as a template to add more rendering engines.
-# You will need to make sure your file is named with a same name (case sensitive)
-# That you will use everywhere to describe your renderer, ex: Appleseed or Povray
+# You will need to make sure your file is named with a same name (case
+# sensitive)
+# That you will use everywhere to describe your renderer, ex: Appleseed or
+# Povray
 
 
 # A render engine module must contain the following functions:
 #
-#    writeCamera(por,rot,up,target): returns a string containing an openInventor camera string in renderer format
-#    writeObject(view,mesh,color,alpha): returns a string containing a RaytracingView object in renderer format
-#    render(project,prefix,external,output,width,height): renders the given project, external means
-#                                                         if the user wishes to open the render file
-#                                                         in an external application/editor or not. If this
-#                                                         is not supported by your renderer, you can simply
-#                                                         ignore it
+# write_camera(pos, rot, up, target, name)
+#   returns a string containing an openInventor camera string in renderer
+#   format
+#
+# write_object(view, mesh, color, alpha)
+#   returns a string containing a RaytracingView object in renderer format
+#
+# render(project, prefix, external, output, width, height)
+#   renders the given project
+#   external means if the user wishes to open the render file in an external
+#   application/editor or not. If this is not supported by your renderer, you
+#   can simply ignore it
 #
 # Additionally, you might need/want to add:
-#
-#    Preference page items, that can be used in your functions below
-#    An icon under the name Renderer.svg (where Renderer is the name of your Renderer
+#   Preference page items, that can be used in your functions below
+#   An icon under the name Renderer.svg (where Renderer is the name of your
+#   Renderer
 
 
-# NOTE: The coordinate system in appleseed uses a different coordinate system.
+# NOTE: The coordinate system in Appleseed uses a different coordinate system.
 # Y and Z are switched and Z is inverted
 
-import tempfile
-import FreeCAD
 import os
-import math
 import re
+from tempfile import mkstemp
+from math import pi
+
+import FreeCAD as App
 
 
-def writeCamera(pos,rot,up,target):
-
-    # this is where you create a piece of text in the format of
+def write_camera(pos, rot, updir, target, name):
+    """Compute a string in the format of Appleseed, that represents a camera"""
+    # This is where you create a piece of text in the format of
     # your renderer, that represents the camera.
 
-    target = str(target.x)+" "+str(target.z)+" "+str(-target.y)
-    up = str(up.x)+" "+str(up.z)+" "+str(-up.y)
-    pos = str(pos.x)+" "+str(pos.z)+" "+str(-pos.y)
-
-    cam = """
+    snippet = """
         <camera name="camera" model="thinlens_camera">
             <parameter name="film_width" value="0.032" />
+            <parameter name="film_height" value="0.032" />
             <parameter name="aspect_ratio" value="1.7" />
-            <parameter name="horizontal_fov" value="80" />
+            <parameter name="horizontal_fov" value="40" />
             <parameter name="shutter_open_time" value="0" />
             <parameter name="shutter_close_time" value="1" />
+            <parameter name="focal_distance" value="1" />
+            <parameter name="f_stop" value="8" />
             <transform>
-                <look_at origin="%s" target="%s" up="%s" />
+                <look_at origin="{} {} {}"
+                         target="{} {} {}"
+                         up="{} {} {}" />
             </transform>
-        </camera>""" % (pos, target, up)
+        </camera>"""
 
-    return cam
+    return snippet.format(pos.x, pos.z, -pos.y,
+                          target.x, target.z, -target.y,
+                          updir.x, updir.z, -updir.y)
 
 
-def writeObject(viewobj,mesh,color,alpha):
-
+def write_object(viewobj, mesh, color, alpha):
+    """Compute a string in the format of Appleseed, that represents a FreeCAD
+    object
+    """
     # This is where you write your object/view in the format of your
     # renderer. "obj" is the real 3D object handled by this project, not
     # the project itself. This is your only opportunity
     # to write all the data needed by your object (geometry, materials, etc)
     # so make sure you include everything that is needed
 
-    objname = viewobj.Name
-    colorname = objname + "_color"
-    bsdfname = objname + "_bsdf"
-    matname = objname + "_mat"
-
-    # format color and alpha
-
-    color = str(color[0])+" "+str(color[1])+" "+str(color[2])
-    alpha = str(alpha)
-
-    # write the mesh as an obj tempfile
-
-    fd, meshfile = tempfile.mkstemp(suffix=".obj", prefix="_")
-    os.close(fd)
-    objfile = os.path.splitext(os.path.basename(meshfile))[0]
-    import math
+    # Write the mesh as an OBJ tempfile
+    f_handle, objfile = mkstemp(suffix=".obj", prefix="_")
+    os.close(f_handle)
     tmpmesh = mesh.copy()
-    tmpmesh.rotate(-math.pi/2,0,0)
-    tmpmesh.write(meshfile)
+    tmpmesh.rotate(-pi/2, 0, 0)
+    tmpmesh.write(objfile)
 
-    # fix for missing object name in obj file (mandatory in Appleseed)
-    f = open(meshfile, "r")
-    contents = f.readlines()
-    f.close()
-    n = []
-    found = False
-    for l in contents:
-        if (not found) and l.startswith("f "):
-            found = True
-            n.append("o "+objname+"\n")
-        n.append(l)
-    f = open(meshfile, "w")
-    contents = "".join(n)
-    f.write(contents)
-    f.close()
+    # Fix missing object name in OBJ file (mandatory in Appleseed)
+    # We want to insert a 'o ...' statement before the first 'f ...'
+    with open(objfile, "r") as f:
+        buffer = f.readlines()
 
-    objdef = """
-            <color name="%s">
+    i = next(i for i, l in enumerate(buffer) if l.startswith("f "))
+    buffer.insert(i, "o %s\n" % viewobj.Name)
+
+    with open(objfile, "w") as f:
+        f.write("".join(buffer))
+
+    # Format output
+    snippet = """
+            <!-- Generated by FreeCAD - Object '{n}' -->
+            <color name="{n}_color">
                 <parameter name="color_space" value="linear_rgb" />
                 <parameter name="multiplier" value="1.0" />
                 <parameter name="wavelength_range" value="400.0 700.0" />
-                <values>
-                    %s
-                </values>
-                <alpha>
-                    %s
-                </alpha>
+                <values> {c[0]} {c[1]} {c[2]} </values>
+                <alpha> {a} </alpha>
             </color>
-            <bsdf name="%s" model="lambertian_brdf">
-                <parameter name="reflectance" value="%s" />
+            <bsdf name="{n}_bsdf" model="lambertian_brdf">
+                <parameter name="reflectance" value="{n}_color" />
             </bsdf>
-            <material name="%s" model="generic_material">
-                <parameter name="bsdf" value="%s" />
+            <material name="{n}_mat" model="generic_material">
+                <parameter name="bsdf" value="{n}_bsdf" />
                 <parameter name="bump_amplitude" value="1.0" />
                 <parameter name="bump_offset" value="2.0" />
                 <parameter name="displacement_method" value="bump" />
                 <parameter name="normal_map_up" value="z" />
                 <parameter name="shade_alpha_cutouts" value="false" />
             </material>
-            <object name="%s" model="mesh_object">
-                <parameter name="filename" value="%s" />
+            <object name="{o}" model="mesh_object">
+                <parameter name="filename" value="{f}" />
             </object>
-            <object_instance name="%s.instance" object="%s">
-                <assign_material slot="default" side="front" material="%s" />
-                <assign_material slot="default" side="back" material="%s" />
-            </object_instance>""" % (colorname, color, alpha,
-                                    bsdfname, colorname,
-                                    matname, bsdfname,
-                                    objfile, meshfile,
-                                    objfile+"."+objname,
-                                    objfile+"."+objname,
-                                    matname, matname)
+            <object_instance name="{o}.{n}.instance" object="{o}.{n}">
+                <assign_material slot="default"
+                                 side="front"
+                                 material="{n}_mat" />
+                <assign_material slot="default"
+                                 side="back"
+                                 material="{n}_mat" />
+            </object_instance>"""
 
-    return objdef
+    return snippet.format(n=viewobj.Name,
+                          c=color,
+                          a=alpha,
+                          o=os.path.splitext(os.path.basename(objfile))[0],
+                          f=objfile)
 
 
-def writePointLight(view,location,color,power):
-    # this is where you write the renderer-specific code
+def write_pointlight(view, location, color, power):
+    """Compute a string in the format of Appleseed, that represents a
+    PointLight object
+    """
+    # This is where you write the renderer-specific code
     # to export the point light in the renderer format
 
     # TODO
     return ""
 
-def render(project,prefix,external,output,width,height):
 
-    # here you trigger a render by firing the renderer
+def render(project, prefix, external, output, width, height):
+    """Run Appleseed
+
+    Params:
+    - project:  the project to render
+    - prefix:   a prefix string for call (will be inserted before path to
+                renderer)
+    - external: a boolean indicating whether to call UI (true) or console
+                (false) version of renderder
+    - width:    rendered image width, in pixels
+    - height:   rendered image height, in pixels
+
+    Return:     path to output image file
+    """
+    # Here you trigger a render by firing the renderer
     # executable and passing it the needed arguments, and
     # the file it needs to render
 
-    # change image size in template
-    f = open(project.PageResult,"r")
-    t = f.read()
-    f.close()
-    res = re.findall("<parameter name=\"resolution.*?\/>",t)
+    # Change image size in template
+    with open(project.PageResult, "r") as f:
+        template = f.read()
+    res = re.findall(r"<parameter name=\"resolution.*?\/>", template)
     if res:
-        t = t.replace(res[0],"<parameter name=\"resolution\" value=\""+str(width)+" "+str(height)+"\" />")
-        fd, fp = tempfile.mkstemp(prefix=project.Name,suffix=os.path.splitext(project.Template)[-1])
-        os.close(fd)
-        f = open(fp,"w")
-        f.write(t)
-        f.close()
-        project.PageResult = fp
-        os.remove(fp)
-        FreeCAD.ActiveDocument.recompute()
+        snippet = '<parameter name="resolution" value="{} {}"/>'
+        template = template.replace(res[0], snippet.format(width, height))
+        f_handle, f_path = mkstemp(
+            prefix=project.Name,
+            suffix=os.path.splitext(project.Template)[-1])
+        os.close(f_handle)
+        with open(f_path, "w") as f:
+            f.write(template)
+        project.PageResult = f_path
+        os.remove(f_path)
+        App.ActiveDocument.recompute()
 
-    p = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Render")
+    # Prepare parameters
+    params = App.ParamGet("User parameter:BaseApp/Preferences/Mod/Render")
     if external:
-        rpath = p.GetString("AppleseedStudioPath","")
+        rpath = params.GetString("AppleseedStudioPath", "")
         args = ""
     else:
-        rpath = p.GetString("AppleseedCliPath","")
-        args = p.GetString("AppleseedParameters","")
+        rpath = params.GetString("AppleseedCliPath", "")
+        args = params.GetString("AppleseedParameters", "")
         if args:
             args += " "
-        args += "--output "+output
+        args += "--output " + output
     if not rpath:
-        FreeCAD.Console.PrintError("Unable to locate renderer executable. Please set the correct path in Edit -> Preferences -> Render")
-        return
+        App.Console.PrintError("Unable to locate renderer executable. "
+                               "Please set the correct path in "
+                               "Edit -> Preferences -> Render")
+        return ""
     if args:
         args += " "
-    os.system(prefix+rpath+" "+args+project.PageResult)
-    return
-
-
+    os.system(prefix + rpath + " " + args + project.PageResult)
+    return output

--- a/renderers/Cycles.py
+++ b/renderers/Cycles.py
@@ -1,175 +1,193 @@
-from __future__ import print_function
-#***************************************************************************
-#*                                                                         *
-#*   Copyright (c) 2019 Yorik van Havre <yorik@uncreated.net>              *
-#*                                                                         *
-#*   This program is free software; you can redistribute it and/or modify  *
-#*   it under the terms of the GNU Lesser General Public License (LGPL)    *
-#*   as published by the Free Software Foundation; either version 2 of     *
-#*   the License, or (at your option) any later version.                   *
-#*   for detail see the LICENCE text file.                                 *
-#*                                                                         *
-#*   This program is distributed in the hope that it will be useful,       *
-#*   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
-#*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
-#*   GNU Library General Public License for more details.                  *
-#*                                                                         *
-#*   You should have received a copy of the GNU Library General Public     *
-#*   License along with this program; if not, write to the Free Software   *
-#*   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
-#*   USA                                                                   *
-#*                                                                         *
-#***************************************************************************
+# ***************************************************************************
+# *                                                                         *
+# *   Copyright (c) 2019 Yorik van Havre <yorik@uncreated.net>              *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   This program is distributed in the hope that it will be useful,       *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with this program; if not, write to the Free Software   *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
 
-# Cycles renderer for FreeCAD
+"""Cycles renderer for FreeCAD"""
 
 # This file can also be used as a template to add more rendering engines.
-# You will need to make sure your file is named with a same name (case sensitive)
-# That you will use everywhere to describe your renderer, ex: Appleseed or Povray
+# You will need to make sure your file is named with a same name (case
+# sensitive)
+# That you will use everywhere to describe your renderer, ex: Appleseed or
+# Povray
 
 
 # A render engine module must contain the following functions:
 #
-#    writeCamera(por,rot,up,target): returns a string containing an openInventor camera string in renderer format
-#    writeObject(view,mesh,color,alpha): returns a string containing a RaytracingView object in renderer format
-#    render(project,prefix,external,output,width,height): renders the given project, external means 
-#                                                         if the user wishes to open the render file 
-#                                                         in an external application/editor or not. If this
-#                                                         is not supported by your renderer, you can simply 
-#                                                         ignore it
+# write_camera(pos, rot, up, target)
+#   returns a string containing an openInventor camera string in renderer
+#   format
+#
+# write_object(view, mesh, color, alpha)
+#   returns a string containing a RaytracingView object in renderer format
+#
+# render(project, prefix, external, output, width, height)
+#   renders the given project
+#   external means if the user wishes to open the render file in an external
+#   application/editor or not. If this is not supported by your renderer, you
+#   can simply ignore it
 #
 # Additionally, you might need/want to add:
-#
-#    Preference page items, that can be used in your functions below
-#    An icon under the name Renderer.svg (where Renderer is the name of your Renderer
+#   Preference page items, that can be used in your functions below
+#   An icon under the name Renderer.svg (where Renderer is the name of your
+#   Renderer
 
 
-import tempfile
-import FreeCAD
 import os
-import math
-import re
+from math import degrees
+
+import FreeCAD as App
 
 
-def writeCamera(pos,rot,up,target):
+def write_camera(pos, rot, updir, target, name):
+    """Compute a string in the format of Cycles, that represents a camera"""
 
-    # this is where you create a piece of text in the format of
+    # This is where you create a piece of text in the format of
     # your renderer, that represents the camera.
 
-    pos = str(pos.x)+" "+str(pos.y)+" "+str(pos.z)
-    rot = str(math.degrees(rot.Angle))+" "+str(rot.Axis.x)+" "+str(rot.Axis.y)+" "+str(rot.Axis.z)
+    # Cam rotation is angle(deg) axisx axisy axisz
+    # Scale needs to have z inverted to behave like a decent camera.
+    # No idea what they have been doing at blender :)
+    snippet = """
+    <!-- Generated by FreeCAD - Camera '{n}' -->
+    <transform rotate="{a} {r.x} {r.y} {r.z}"
+               translate="{p.x} {p.y} {p.z}"
+               scale="1 1 -1">
+        <camera type="perspective"/>
+    </transform>"""
 
-    # cam rotation is angle(deg) axisx axisy axisz
-    # scale needs to have z inverted to behave like a decent camera. No idea what they have been doing at blender :)
-    cam = """    <transform rotate="%s" translate="%s" scale="1 1 -1">
-        <camera type="perspective" />
-    </transform>""" % (rot, pos)
-
-    return cam
+    return snippet.format(n=name, a=degrees(rot.Angle), r=rot.Axis, p=pos)
 
 
-def writeObject(viewobj,mesh,color,alpha):
-
+def write_object(viewobj, mesh, color, alpha):
+    """Compute a string in the format of Cycles, that represents a FreeCAD
+    object
+    """
     # This is where you write your object/view in the format of your
     # renderer. "obj" is the real 3D object handled by this project, not
     # the project itself. This is your only opportunity
     # to write all the data needed by your object (geometry, materials, etc)
     # so make sure you include everything that is needed
 
-    bsdfname = viewobj.Name + "_bsdf"
-    matname = viewobj.Name + "_mat"
-    transname = viewobj.Name + "_trans"
-    mixname = viewobj.Name + "_mix"
+    snippet1 = """
+    <!-- Generated by FreeCAD - Object '{n}' -->
+    <shader name="{n}_mat">
+        <diffuse_bsdf name="{n}_bsdf" color="{c[0]}, {c[1]}, {c[2]}"/>"""
 
-    # format color data
+    snippet2a = """
+        <transparent_bsdf name="{n}_trans" color="1.0, 1.0, 1.0"/>
+        <mix_closure name="{n}_mix" fac="{a}"/>
+        <connect from="{n}_trans bsdf"  to="{n}_mix closure1"/>
+        <connect from="{n}_bsdf bsdf"   to="{n}_mix closure2"/>
+        <connect from="{n}_mix closure" to="output surface"/>
+    </shader>"""
 
-    color = str(color[0])+", "+str(color[1])+", "+str(color[2])
-    
-    # write shader
-    
-    objdef =      "    <shader name=\""+matname+"\">\n"
-    objdef +=     "        <diffuse_bsdf name=\""+bsdfname+"\" color=\""+color+"\" />\n"
-    if alpha < 1:
-        objdef += "        <transparent_bsdf name=\""+transname+"_trans\" color=\"1.0, 1.0, 1.0\" />\n"
-        objdef += "        <mix_closure name=\""+mixname+"\" fac=\""+str(alpha)+"\" />\n"
-        objdef += "        <connect from=\""+transname+" bsdf\" to=\""+mixname+" closure1\" />\n"
-        objdef += "        <connect from=\""+bsdfname+" bsdf\" to=\""+mixname+" closure2\" />\n"
-        objdef += "        <connect from=\""+mixname+" closure\" to=\"output surface\" />\n"
-    else:
-        objdef += "        <connect from=\""+bsdfname+" bsdf\" to=\"output surface\" />\n"
-    objdef +=     "    </shader>\n\n"
-    
-    # write mesh
+    snippet2b = """
+        <connect from="{n}_bsdf bsdf"   to="output surface"/>
+    </shader>"""
 
-    P = ""
-    nverts = ""
-    verts = ""
-    for v in mesh.Topology[0]:
-        P += str(v.x) + " " + str(v.y) + " " + str(v.z) + "  "
-    for f in mesh.Topology[1]:
-        nverts += "3 "
-        verts += str(f[0]) + " " + str(f[1]) + " " + str(f[2]) + "  "
-    P = P.strip()
-    nverts = nverts.strip()
-    verts = verts.strip()
-    objdef += "    <state shader=\""+matname+"\">\n"
-    objdef += "        <mesh P=\""+P+"\" nverts=\""+nverts+"\" verts=\""+verts+"\" />\n"
-    objdef += "    </state>\n\\n"
+    snippet3 = """
+    <state shader="{n}_mat">
+        <mesh P="{p}"
+              nverts="{i}"
+              verts="{v}"/>
+    </state>\n"""
 
-    return objdef
+    snippet = snippet1 + (snippet2a if alpha < 1 else snippet2b) + snippet3
+
+    points = ["{0.x} {0.y} {0.z}".format(p) for p in mesh.Topology[0]]
+    verts = ["{} {} {}".format(*v) for v in mesh.Topology[1]]
+    nverts = ["3"] * len(verts)
+
+    return snippet.format(n=viewobj.Name,
+                          c=color,
+                          a=alpha,
+                          p="  ".join(points),
+                          i="  ".join(nverts),
+                          v="  ".join(verts))
 
 
-def writePointLight(view,location,color,power):
-    # this is where you write the renderer-specific code
+def write_pointlight(view, location, color, power):
+    """Compute a string in the format of Cycles, that represents a
+    PointLight object
+    """
+    # This is where you write the renderer-specific code
     # to export a point light in the renderer format
 
-    col = "{}, {}, {}".format(*color)
+    snippet = """
+    <!-- Generated by FreeCAD - Pointlight '{n}' -->
+    <shader name="{n}_shader">
+        <emission name="{n}_emit"
+                  color="{c[0]},{c[1]},{c[2]}"
+                  strength="1"/>
+        <connect from="{n}_emit emission"
+                 to="output surface"/>
+    </shader>
+    <state shader="{n}_shader">
+        <light type="point"
+               co="{p.x} {p.y} {p.z}"
+               strength="{s} {s} {s}"/>
+    </state>\n"""
 
-    objdef = list()
-
-    # Write shader
-    objdef.append('    <shader name="{}_shader">'.format(view.Name))
-    objdef.append('        <emission name="{}_emit" color="{}" strength="1" />'\
-            .format(view.Name,col))
-    objdef.append('        <connect from="{}_emit emission" to="output surface" />'\
-            .format(view.Name))
-    objdef.append('    </shader>')
-    objdef.append('\n')
-
-    # Write light
-    objdef.append('    <state shader="{}_shader">'.format(view.Name))
-    objdef.append('        <light type="point" co="{} {} {}" strength="{s} {s} {s}" />'\
-            .format(location.x,location.y,location.z,s=power*100))
-    objdef.append('    </state>')
-    objdef.append('\n')
+    return snippet.format(n=view.Name,
+                          c=color,
+                          p=location,
+                          s=power*100)
 
 
-    return "\n".join(objdef)
+def render(project, prefix, external, output, width, height):
+    """Run Cycles
 
-def render(project,prefix,external,output,width,height):
+    Params:
+    - project:  the project to render
+    - prefix:   a prefix string for call (will be inserted before path to Lux)
+    - external: a boolean indicating whether to call UI (true) or console
+                (false) version of Lux
+    - width:    rendered image width, in pixels
+    - height:   rendered image height, in pixels
 
-    # here you trigger a render by firing the renderer
+    Return: path to output image file
+    """
+
+    # Here you trigger a render by firing the renderer
     # executable and passing it the needed arguments, and
     # the file it needs to render
 
-    p = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Render")
-    prefix = p.GetString("Prefix","")
+    params = App.ParamGet("User parameter:BaseApp/Preferences/Mod/Render")
+    prefix = params.GetString("Prefix", "")
     if prefix:
         prefix += " "
-    rpath = p.GetString("CyclesPath","")
-    args = p.GetString("CyclesParameters","")
-    args += " --output "+output
+    rpath = params.GetString("CyclesPath", "")
+    args = params.GetString("CyclesParameters", "")
+    args += " --output " + output
     if not external:
         args += " --background"
     if not rpath:
-        FreeCAD.Console.PrintError("Unable to locate renderer executable. Please set the correct path in Edit -> Preferences -> Render")
-        return
-    args += " --width "+str(width)
-    args += " --height "+str(height)
-    cmd = prefix+rpath+" "+args+" "+project.PageResult
-    print(cmd+'\n')
+        App.Console.PrintError("Unable to locate renderer executable. "
+                               "Please set the correct path in "
+                               "Edit -> Preferences -> Render")
+        return ""
+    args += " --width " + str(width)
+    args += " --height " + str(height)
+    cmd = prefix + rpath + " " + args + " " + project.PageResult
+    App.Console.PrintMessage(cmd+'\n')
     os.system(cmd)
 
     return output
-
-

--- a/renderers/Luxrender.py
+++ b/renderers/Luxrender.py
@@ -1,193 +1,216 @@
-#***************************************************************************
-#*                                                                         *
-#*   Copyright (c) 2017 Yorik van Havre <yorik@uncreated.net>              *
-#*                                                                         *
-#*   This program is free software; you can redistribute it and/or modify  *
-#*   it under the terms of the GNU Lesser General Public License (LGPL)    *
-#*   as published by the Free Software Foundation; either version 2 of     *
-#*   the License, or (at your option) any later version.                   *
-#*   for detail see the LICENCE text file.                                 *
-#*                                                                         *
-#*   This program is distributed in the hope that it will be useful,       *
-#*   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
-#*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
-#*   GNU Library General Public License for more details.                  *
-#*                                                                         *
-#*   You should have received a copy of the GNU Library General Public     *
-#*   License along with this program; if not, write to the Free Software   *
-#*   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
-#*   USA                                                                   *
-#*                                                                         *
-#***************************************************************************
+# ***************************************************************************
+# *                                                                         *
+# *   Copyright (c) 2017 Yorik van Havre <yorik@uncreated.net>              *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   This program is distributed in the hope that it will be useful,       *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with this program; if not, write to the Free Software   *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
 
-# Luxrender renderer for FreeCAD
+"""Luxrender renderer for FreeCAD"""
 
 # This file can also be used as a template to add more rendering engines.
-# You will need to make sure your file is named with a same name (case sensitive)
-# That you will use everywhere to describe your renderer, ex: Appleseed or Povray
+# You will need to make sure your file is named with a same name (case
+# sensitive)
+# That you will use everywhere to describe your renderer, ex: Appleseed or
+# Povray
 
 
 # A render engine module must contain the following functions:
 #
-#    writeCamera(por,rot,up,target): returns a string containing an openInventor camera string in renderer format
-#    writeObject(view,mesh,color,alpha): returns a string containing a RaytracingView object in renderer format
-#    render(project,prefix,external,output,width,height): renders the given project, external means
-#                                                         if the user wishes to open the render file
-#                                                         in an external application/editor or not. If this
-#                                                         is not supported by your renderer, you can simply
-#                                                         ignore it
+# write_camera(pos, rot, up, target)
+#   returns a string containing an openInventor camera string in renderer
+#   format
+#
+# write_object(view, mesh, color, alpha)
+#   returns a string containing a RaytracingView object in renderer format
+#
+# render(project, prefix, external, output, width, height)
+#   renders the given project
+#   external means if the user wishes to open the render file in an external
+#   application/editor or not. If this is not supported by your renderer, you
+#   can simply ignore it
 #
 # Additionally, you might need/want to add:
-#
-#    Preference page items, that can be used in your functions below
-#    An icon under the name Renderer.svg (where Renderer is the name of your Renderer
+#   Preference page items, that can be used in your functions below
+#   An icon under the name Renderer.svg (where Renderer is the name of your
+#   Renderer
 
 
-import FreeCAD
-import math
 import os
 import re
-import tempfile
 import shlex
-import subprocess
+from tempfile import mkstemp
+from subprocess import Popen
+from textwrap import dedent
+
+import FreeCAD as App
 
 
-def writeCamera(pos,rot,up,target):
-
-    # this is where you create a piece of text in the format of
+def write_camera(pos, rot, updir, target, name):
+    """Compute a string in the format of Luxrender, that represents a camera"""
+    # This is where you create a piece of text in the format of
     # your renderer, that represents the camera.
 
-    pos = str(pos.x) + " " + str(pos.y) + " " + str(pos.z)
-    target = str(target.x) + " " + str(target.y) + " " + str(target.z)
-    up = str(up.x) + " " + str(up.y) + " " + str(up.z)
+    snippet = """
+    # Generated by FreeCAD (http://www.freecadweb.org/)
+    # Declares position and view direction (camera '{0}')
+    LookAt   {1.x} {1.y} {1.z}   {2.x} {2.y} {2.z}   {3.x} {3.y} {3.z}
+    \n"""
 
-    cam  = "# declares position and view direction\n"
-    cam += "# Generated by FreeCAD (http://www.freecadweb.org/)\n"
-    cam += "LookAt " + pos + " "
-    cam += target + " "
-    cam += up + "\n"
-    return cam
+    return dedent(snippet).format(name, pos, target, updir)
 
-def writeObject(viewobj,mesh,color,alpha):
 
+def write_object(viewobj, mesh, color, alpha):
+    """Compute a string in the format of Luxrender, that represents a FreeCAD
+    object
+    """
     # This is where you write your object/view in the format of your
     # renderer. "obj" is the real 3D object handled by this project, not
     # the project itself. This is your only opportunity
     # to write all the data needed by your object (geometry, materials, etc)
     # so make sure you include everything that is needed
 
-
-    objname = viewobj.Name
-
-    # format color
-    color = "{} {} {}".format(*color)
-
-    # get geometry
-    P = ["{} {} {}".format(v.x, v.y, v.z) for v in mesh.Topology[0]]
-    P = " ".join(P)
-    N = ["{} {} {}".format(n.x, n.y, n.z) for n in mesh.getPointNormals()]
-    N = " ".join(N)
+    points = ["{0.x} {0.y} {0.z}".format(v) for v in mesh.Topology[0]]
+    norms = ["{0.x} {0.y} {0.z}".format(n) for n in mesh.getPointNormals()]
     tris = ["{} {} {}".format(*t) for t in mesh.Topology[1]]
-    tris = " ".join(tris)
 
-    objdef = list()
+    snippet = """
+    # Generated by FreeCAD (http://www.freecadweb.org/)
+    MakeNamedMaterial "{name}_mat"
+        "color Kd"              [{colo[0]} {colo[1]} {colo[2]}]
+        "float sigma"           [0.2]
+        "string type"           ["matte"]
+        "float transparency"    [{trsp}]
 
-    # write shader
-    objdef.append('MakeNamedMaterial "{}_mat"'.format(objname))
-    objdef.append('    "color Kd"       [{}]'.format(color))
-    objdef.append('    "float sigma"    [0.2]')
-    objdef.append('    "string type"    ["matte"]')
-    if alpha < 1.0:
-        objdef.append('    "float transparency" ["{}"]'.format(alpha))
-    objdef.append('\n')
+    AttributeBegin  # {name}
+    Transform [1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1]
+    NamedMaterial "{name}_mat"
+    Shape "mesh"
+        "integer triindices" [{inds}]
+        "point P" [{pnts}]
+        "normal N" [{nrms}]
+        "bool generatetangents" ["false"]
+        "string name" ["{name}"]
+    AttributeEnd  # {name}
+    """
 
-    # write mesh
-    objdef.append('AttributeBegin # "{}"'.format(objname))
-    objdef.append('Transform [1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1]')
-    objdef.append('NamedMaterial "{}_mat"'.format(objname))
-    objdef.append('Shape "mesh"')
-    objdef.append('    "integer triindices" [{}]'.format(tris))
-    objdef.append('    "point P" [{}]'.format(P))
-    objdef.append('    "normal N" [{}]'.format(N))
-    objdef.append('    "bool generatetangents" ["false"]')
-    objdef.append('    "string name" ["{}"]'.format(objname))
-    objdef.append('AttributeEnd # "{}_mat"'.format(objname))
-    objdef.append('\n')
-
-    return "\n".join(objdef)
+    return dedent(snippet).format(name=viewobj.Name,
+                                  colo=color,
+                                  trsp=alpha if alpha < 1.0 else 1.0,
+                                  inds=" ".join(tris),
+                                  pnts=" ".join(points),
+                                  nrms=" ".join(norms))
 
 
-
-def writePointLight(view,location,color,power):
-    # this is where you write the renderer-specific code
+def write_pointlight(view, location, color, power):
+    """Compute a string in the format of Luxrender, that represents a
+    PointLight object
+    """
+    # This is where you write the renderer-specific code
     # to export the point light in the renderer format
 
     # From Luxcore doc:
     # power is in watts
     # efficency (sic) is in lumens/watt
-    efficency = 15 # incandescent light bulb ratio (average)
-    gain = 10 # Guesstimated! (don't hesitate to propose a more sensible value)
+    efficency = 15  # incandescent light bulb ratio (average)
+    gain = 10  # Guesstimated! (don't hesitate to propose more sensible values)
 
-    objdef = list()
-    objdef.append('AttributeBegin # "{}"'.format(view.Name))
-    objdef.append('Transform [1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1]')
-    objdef.append('LightSource "point"')
-    objdef.append('     "float from"        [{:.9f} {:.9f} {:.9f}]'.format(*location))
-    objdef.append('     "color L"           [{:.9f} {:.9f} {:.9f}]'.format(*color))
-    objdef.append('     "float power"       [{:.9f}]'.format(power))
-    objdef.append('     "float efficency"   [{:.9f}]'.format(efficency))
-    objdef.append('     "float gain"        [{:.9f}]'.format(gain))
-    objdef.append('AttributeEnd # "{}"'.format(view.Name))
-    objdef.append('\n')
+    snippet = """
+    # Generated by FreeCAD (http://www.freecadweb.org)
+    AttributeBegin # {n}
+    Transform [1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1]
+    LightSource "point"
+         "float from"        [{f.x} {f.y} {f.z}]
+         "color L"           [{L[0]} {L[1]} {L[2]}]
+         "float power"       [{p}]
+         "float efficency"   [{e}]
+         "float gain"        [{g}]
+    AttributeEnd # {n}
+    \n"""
 
-    return "\n".join(objdef)
+    return dedent(snippet).format(n=view.Name,
+                                  f=location,
+                                  L=color,
+                                  p=power,
+                                  e=efficency,
+                                  g=gain)
 
-def render(project,prefix,external,output,width,height):
 
-    # here you trigger a render by firing the renderer
+def render(project, prefix, external, output, width, height):
+    """Run Luxrender
+
+    Params:
+    - project:  the project to render
+    - prefix:   a prefix string for call (will be inserted before path to Lux)
+    - external: a boolean indicating whether to call UI (true) or console
+                (false) version of Lux
+    - width:    rendered image width, in pixels
+    - height:   rendered image height, in pixels
+
+    Return: void
+    """
+    # Here you trigger a render by firing the renderer
     # executable and passing it the needed arguments, and
     # the file it needs to render
 
     # change image size in template
-    f = open(project.PageResult,"r")
-    t = f.read()
-    f.close()
-    res = re.findall("integer xresolution",t)
-    if res:
-        t = re.sub("\"integer xresolution\".*?\[.*?\]","\"integer xresolution\" ["+str(width)+"]",t)
-    res = re.findall("integer yresolution",t)
-    if res:
-        t = re.sub("\"integer yresolution\".*?\[.*?\]","\"integer yresolution\" ["+str(height)+"]",t)
-    if res:
-        fd, fp = tempfile.mkstemp(prefix=project.Name,suffix=os.path.splitext(project.Template)[-1])
-        os.close(fd)
-        f = open(fp,"w")
-        f.write(t)
-        f.close()
-        project.PageResult = fp
-        os.remove(fp)
-        FreeCAD.ActiveDocument.recompute()
+    with open(project.PageResult, "r") as f:
+        template = f.read()
 
-    p = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Render")
-    if external:
-        rpath = p.GetString("LuxRenderPath","")
-        args = p.GetString("LuxParameters","")
-    else:
-        rpath = p.GetString("LuxConsolePath","")
-        args = p.GetString("LuxParameters","")
+    res = re.findall("integer xresolution", template)
+    if res:
+        template = re.sub(r'"integer xresolution".*?\[.*?\]',
+                          '"integer xresolution" [{}]'.format(width),
+                          template)
+
+    res = re.findall("integer yresolution", template)
+    if res:
+        template = re.sub(r'"integer yresolution".*?\[.*?\]',
+                          '"integer yresolution" [{}]'.format(height),
+                          template)
+
+    if res:
+        f_handle, f_path = mkstemp(
+            prefix=project.Name,
+            suffix=os.path.splitext(project.Template)[-1])
+        os.close(f_handle)
+        with open(f_path, "w") as f:
+            f.write(template)
+        project.PageResult = f_path
+        os.remove(f_path)
+        App.ActiveDocument.recompute()
+
+    params = App.ParamGet("User parameter:BaseApp/Preferences/Mod/Render")
+    args = params.GetString("LuxParameters", "")
+    rpath = params.GetString("LuxRenderPath" if external
+                             else "LuxConsolePath", "")
     if not rpath:
-        FreeCAD.Console.PrintError("Unable to locate renderer executable. Please set the correct path in Edit -> Preferences -> Render")
+        App.Console.PrintError("Unable to locate renderer executable. "
+                               "Please set the correct path in "
+                               "Edit -> Preferences -> Render")
         return
-    if args:
-        args += " "
 
     # Call Luxrender
-    cmd = prefix + rpath + " " + args + project.PageResult + "\n"
-    FreeCAD.Console.PrintMessage(cmd)
+    cmd = prefix + rpath + " " + args + " " + project.PageResult + "\n"
+    App.Console.PrintMessage(cmd)
     try:
-        p = subprocess.Popen(shlex.split(cmd))
-    except OSError as e:
-        FreeCAD.Console.PrintError("Luxrender call failed: '" + e.strerror +"'\n")
+        Popen(shlex.split(cmd))
+    except OSError as err:
+        msg = "Luxrender call failed: '" + err.strerror + "'\n"
+        App.Console.PrintError(msg)
 
     return
-


### PR DESCRIPTION
This PR aims at improving code quality, with no added functionality. The goal is to make code more readable, maintainable and extendable.
It mainly enforces PEP8 and PEP 257 on existing files, but beyond that, an attempt was sometimes also made to make code more "pythonic" (use of language idioms: list comprehensions, context managers, format specification mini-language...).

In detail:
* Lint code
  * Run pylint and flake8, and correct warnings/errors emitted whenever possible: lines too long, unused variables, naming rules violations, imports position in file and order, max number of statements in functions/methods, blank lines rules violation etc.
  * Add docstrings wherever required
  * Add a 'pylintrc' file for subsequent use
  * Add a mention about code quality ambition in README.md
  * Add some additional comments
* Improve code pythonicity
  * Use context managers for file operations
  * Use python format specification mini-language in lieu of (more cumbersome) concatenation, in external renderers modules
  * Use idioms (list comprehensions, expression generators, ternary operator...) wherever relevant
* Make some light refactoring:
  * Create a RendererHandler class to simplify interactions with external renderers modules (façade design pattern), also to reduce number of statements in Project.render()
  * Create factory methods for Project, View and Camera objects
  * Remove (previously empty) License section in README.md and add a LICENCE file instead (LGPL2, directly copied from FreeCAD directory)