### PR TITLE
Add support for groups in rendering projects and improve view naming

### DIFF
--- a/Render.py
+++ b/Render.py
@@ -848,6 +848,11 @@ class RendererHandler:
         if not mesh:
             return ""
 
+        if not (mesh.Topology[0] and mesh.Topology[1] and
+                mesh.getPointNormals()):
+            # Empty topology makes some renderers crash at parsing...
+            return ""
+
         return self._call_renderer("write_object",
                                    view,
                                    name,


### PR DESCRIPTION
With this PR, it is possible to import a FreeCAD group into a rendering project in a one-click action. The group is recreated in the rendering project.
This PR proposes also a better toponymy for views in rendering projects (namely: object@project)