### PR TITLE
Restore Visibility awareness in rendering

### DIFF
--- a/Render.py
+++ b/Render.py
@@ -419,9 +419,8 @@ class Project:
         get_rdr_string =\
             renderer.get_rendering_string if obj.DelayedBuild\
             else attrgetter("ViewResult")
-        # TODO Reverted to previous functionning due to bug in 0.18
-        # objstrings = [get_rdr_string(v) for v in views if v.Source.Visibility]
-        objstrings = [get_rdr_string(v) for v in views]
+        objstrings = [get_rdr_string(v) for v in views
+                      if v.Source.ViewObject.Visibility]
 
         # Add a ground plane if required
         if getattr(obj, "GroundPlane", False):


### PR DESCRIPTION
Object Visibility awareness in rendering had been disabled due to a compatibility issue with version 0.18. This commit restores it and fixes the issue with version 0.18