### PR TITLE
Create package.xml

### DIFF
--- a/Render/package.xml
+++ b/Render/package.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<package format="1" xmlns="https://wiki.freecad.org/Package_Metadata">
+  <name>Render</name>
+  <description></description>
+  <version>2022-01</version>
+  <date>2022-01-01</date>
+  <maintainer email="@howetuft">howetuft</maintainer>
+  <maintainer email="@yorikvanhave">Yorik Van Havre</maintainer>
+  <license file="LICENSE">LGPLv2.1</license>
+  <url type="repository" branch="master">https://github.com/FreeCAD/FreeCAD-render</url>
+  <url type="bugtracker">https://github.com/FreeCAD/FreeCAD-render/issues</url>
+  <icon>Render/resources/icons/preferences-render.svg</icon>
+
+  <content>
+    <workbench>
+      <classname>RenderWorkbench</classname>
+      <subdirectory>./</subdirectory>
+    </workbench>
+  </content>
+
+</package>


### PR DESCRIPTION
Adds the new package.xml metadata file to the Render WB. Note that I don't have email addresses for either maintainer, so those should be updated. I also invented a version number, you can of course change that to whatever makes sense for the project. The complete documentation for the package.xml file is found here: https://wiki.freecadweb.org/Package_Metadata

Closes #167