### PR TITLE
Base: make Pointables belong to App::GeometryPython class

### DIFF
--- a/Render/base.py
+++ b/Render/base.py
@@ -110,6 +110,7 @@ class FeatureBaseInterface:
     # These constants can be overridden when subclassing (optional)
     NAMESPACE = "Render"  # The namespace where feature and viewprovider are
     TYPE = ""  # The type of the object (str). If empty, default to class name
+    FCDTYPE = ""  # The FreeCAD type of the object (str). If empty, default to "App::FeaturePython"
 
     def on_set_properties_cb(self, fpo):
         """Complete the operation of internal _set_properties (callback).
@@ -241,6 +242,7 @@ class FeatureBase(FeatureBaseInterface):
         """Set underlying FeaturePython object's properties."""
         self.fpo = fpo
         self.__module__ = self.NAMESPACE
+
         fpo.Proxy = self
 
         properties = get_cumulative_dict_attribute(self, "PROPERTIES")
@@ -348,7 +350,8 @@ class FeatureBase(FeatureBaseInterface):
             "and no document is active"
         )
         _type = cls.TYPE if cls.TYPE else cls.__name__
-        fpo = doc.addObject("App::FeaturePython", _type)
+        fcdtype = cls.FCDTYPE if cls.FCDTYPE else "App::FeaturePython"
+        fpo = doc.addObject(fcdtype, _type)
         obj = cls(fpo)
         try:
             viewp_class = getattr(sys.modules[cls.NAMESPACE], cls.VIEWPROVIDER)
@@ -588,6 +591,8 @@ class PointableFeatureMixin:  # pylint: disable=too-few-public-methods
     This mixin allows a feature to be "pointable", ie to support
     'point_at' action.
     """
+
+    FCDTYPE = "App::GeometryPython"
 
     PROPERTIES = {
         "Placement": Prop(

--- a/Render/project.py
+++ b/Render/project.py
@@ -322,7 +322,6 @@ class Project(FeatureBase):
         if not self.fpo.DelayedBuild:
             App.ActiveDocument.recompute()
 
-
     def add_view(self, obj):
         """Add a single object as a new view to the project.
 

--- a/Render/utils.py
+++ b/Render/utils.py
@@ -98,6 +98,7 @@ def reload(module_name=None):
     """Reload Render modules."""
     mods = (
         (
+            "Render.base",
             "Render.camera",
             "Render.commands",
             "Render.constants",


### PR DESCRIPTION
Required by v0.20 to be able to use Placement tool (Edit->Placement...),
as this feature is now restricted only to objects derived from
App::GeoFeature.