### PR TITLE
Revert "Lights: add a (replicated) Placement property in Point Light"

### DIFF
--- a/Render/lights.py
+++ b/Render/lights.py
@@ -36,8 +36,6 @@ import math
 
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
-import FreeCAD as App
-
 from Render.base import (
     FeatureBase,
     PointableFeatureMixin,
@@ -88,25 +86,12 @@ class PointLight(FeatureBase):
 
     VIEWPROVIDER = "ViewProviderPointLight"
 
-    # Note: Point light location is mainly controled by its Location property.
-    # However, to allow the use of Placement and Location features
-    # (Edit-->Placement... & Edit-->Location...), a replicated underlying
-    # Placement property is introduced, and some code has been added to keep it
-    # constantly synchronized with Location.
     PROPERTIES = {
         "Location": Prop(
             "App::PropertyVector",
             "Light",
             QT_TRANSLATE_NOOP("Render", "Location of light"),
             (0, 0, 15),
-        ),
-        "Placement": Prop(
-            "App::PropertyPlacement",
-            "Base",
-            QT_TRANSLATE_NOOP("Render", "Object placement"),
-            App.Placement(App.Vector(0, 0, 0), App.Vector(0, 0, 1), 0),
-            1,
-            5,
         ),
         "Color": Prop(
             "App::PropertyColor",
@@ -132,37 +117,6 @@ class PointLight(FeatureBase):
             2.0,
         ),
     }
-
-    ON_CHANGED = {
-        "Location": "_on_changed_location",
-        "Placement": "_on_changed_placement",
-    }
-
-    FCDTYPE = "App::GeometryPython"
-
-    def _on_changed_location(self, obj):  # pylint: disable=no-self-use
-        """Respond to Location change event (by synchronizing Placement)."""
-        if (
-            "Placement" in obj.PropertiesList
-            and obj.Placement.Base != obj.Location
-        ):
-            obj.Placement.Base = obj.Location
-
-    def _on_changed_placement(self, obj):  # pylint: disable=no-self-use
-        """Respond to Placement change event (by synchronizing Location)."""
-        if (
-            "Location" in obj.PropertiesList
-            and obj.Location != obj.Placement.Base
-        ):
-            obj.Location = obj.Placement.Base
-
-    def on_create_cb(self, fpo, viewp, **kwargs):
-        """Complete the operation of 'create' (callback).
-
-        Initialize Placement.
-        """
-        fpo.setEditorMode("Placement", 3)
-        self._on_changed_location(fpo)
 
 
 class ViewProviderPointLight(


### PR DESCRIPTION
This reverts commit 0c90d6057e62fb79a3860969923fe7a89f3a0559.

Reason: Side-effect when converting an old light (previous location is erased)