### PR TITLE
Bugfix for field of view when using LuxCore with aspect ratio < 1

### DIFF
--- a/Render/renderers/Luxcore.py
+++ b/Render/renderers/Luxcore.py
@@ -143,9 +143,12 @@ scene.shapes.{name}_mesh.faces = {tris}
 
 def write_camera(name, pos, updir, target, fov, resolution, **kwargs):
     """Compute a string in renderer SDL to represent a camera."""
-    # Nota: Luxcore use an horizontal fov, so we have to convert...
+    # The Luxcore fov is in the largest image dimension, so for the typical
+    # case where the image width is larger than the height the vertical fov
+    # used by FreeCAD needs to be converted to a horizontal fov
     orig = pos.Base
-    fov = fovy_to_fovx(fov, *resolution)
+    if resolution[0] > resolution[1]:  # aspect ratio > 1
+        fov = fovy_to_fovx(fov, *resolution)
 
     snippet = f"""
 # Camera '{name}'


### PR DESCRIPTION
The LuxCore renderer's field of view setting applies to the largest image dimension. Currently the vertical fov used by FreeCAD is converted to a horizontal fov for use by LuxCore. For typical images where the width is larger than the height this is fine. However, when rendering an image with width less than height (aspect ratio below 1) this causes the wrong fov to be passed to LuxCore.

I added an if statement to check the aspect ratio and make sure the correct fov is passed.