### PR TITLE
RenderSettings: rename 'label' QLabel to avoid name collisions

### DIFF
--- a/Render/resources/ui/RenderSettings.ui
+++ b/Render/resources/ui/RenderSettings.ui
@@ -24,7 +24,7 @@
      </property>
      <layout class="QGridLayout" name="gridLayout_2">
       <item row="1" column="0">
-       <widget class="QLabel" name="label">
+       <widget class="QLabel" name="as_label">
         <property name="locale">
          <locale language="English" country="UnitedStates"/>
         </property>


### PR DESCRIPTION
(name collisions would have occured with other workbenches UI)