### PR TITLE
Cycles: disable "use light tree"

### DIFF
--- a/templates/cycles_flat.xml
+++ b/templates/cycles_flat.xml
@@ -6,6 +6,7 @@
     method="branched_path"
     sample_all_lights_direct="true"
     sample_all_lights_indirect="true"
+    use_light_tree="false"
 />
 
 <!-- Camera -->

--- a/templates/cycles_standard.xml
+++ b/templates/cycles_standard.xml
@@ -6,6 +6,7 @@
     method="branched_path"
     sample_all_lights_direct="true"
     sample_all_lights_indirect="true"
+    use_light_tree="false"
 />
 
 <!-- Camera -->

--- a/templates/cycles_studio_dark.xml
+++ b/templates/cycles_studio_dark.xml
@@ -6,6 +6,7 @@
     method="branched_path"
     sample_all_lights_direct="true"
     sample_all_lights_indirect="true"
+    use_light_tree="false"
 />
 
 <!-- Camera -->

--- a/templates/cycles_studio_light.xml
+++ b/templates/cycles_studio_light.xml
@@ -6,6 +6,7 @@
     method="branched_path"
     sample_all_lights_direct="true"
     sample_all_lights_indirect="true"
+    use_light_tree="false"
 />
 
 <!-- Camera -->

--- a/templates/cycles_sunlight.xml
+++ b/templates/cycles_sunlight.xml
@@ -6,6 +6,7 @@
     method="branched_path"
     sample_all_lights_direct="true"
     sample_all_lights_indirect="true"
+    use_light_tree="false"
 />
 
 <!-- Camera -->


### PR DESCRIPTION
Light trees were introduced recently. Without further adaptions, they prevent to use more than one light in a scene. For now, we disable, they may be reenabled later (but there will be a compatibility issue).