### PR TITLE
Avoid initialization error when no document open.

### DIFF
--- a/Render/utils.py
+++ b/Render/utils.py
@@ -548,6 +548,8 @@ def _top_objects_gui(doc):
     return objects - children
 
 
-def top_object_names(doc=Gui.ActiveDocument.Document):
+def top_object_names(doc=None):
     """Compute top objects names (debug)."""
+    if not doc and Gui.ActiveDocument:
+        doc = Gui.ActiveDocument.Document
     return [o.Label for o in top_objects(doc)]


### PR DESCRIPTION
At startup if we switch to the Render workbench while no document has been open, the initialization of the workbench fails and leave the it in an unusable state.

This change only make sure that there is an ActiveDocument before using it