### PR TITLE
Passthrough: securize force_uvmap evaluation

### DIFF
--- a/Render/material.py
+++ b/Render/material.py
@@ -234,8 +234,9 @@ class Material(_ArchMaterial):
         trigger the uvmap computation accordingly; this feature allows the
         user to force it."""
         mat = self.fpo.Material
-        res = mat.get("Render.ForceUVMap", "False")
-        res = bool(eval(res))
+        val = mat.get("Render.ForceUVMap", "False")
+        val = val.strip()
+        res = val in ["True", "1"]
         return res
 
 

--- a/Render/taskpanels.py
+++ b/Render/taskpanels.py
@@ -617,10 +617,9 @@ class MaterialSettingsTaskPanel:
         self._populate_passthru(renderer, material)
 
         # Retrieve ForceUVMap
-        try:
-            force_uvmap = bool(eval(material.Material["Render.ForceUVMap"]))
-        except KeyError:
-            force_uvmap = False
+        val = material.Material.get("Render.ForceUVMap", "False")
+        val = val.strip()
+        force_uvmap = val in ["True", "1"]
         self.force_uvmap.setChecked(force_uvmap)
 
         # Retrieve material father


### PR DESCRIPTION
Remove 'eval' use (security hole)