### PR TITLE
Do not break on non Render Materials

### DIFF
--- a/Render/renderables.py
+++ b/Render/renderables.py
@@ -899,7 +899,13 @@ def _needs_uvmap(material):
         return False
 
     proxy = material.Proxy
-    return proxy.has_textures() or proxy.force_uvmap()
+    try:
+        return proxy.has_textures() or proxy.force_uvmap()
+    except AttributeError:
+        App.Console.PrintMessage(
+            f"[Render][Objstrings] Material {proxy} is not a Render Matrial and no texture will be applied\n"
+        )
+        return False
 
 
 def clean_a2p():

--- a/Render/renderables.py
+++ b/Render/renderables.py
@@ -903,7 +903,7 @@ def _needs_uvmap(material):
         return proxy.has_textures() or proxy.force_uvmap()
     except AttributeError:
         App.Console.PrintMessage(
-            f"[Render][Objstrings] Material {proxy} is not a Render Matrial and no texture will be applied\n"
+            f"[Render][Objstrings] Material {proxy} is not a Render Material and no texture will be applied\n"
         )
         return False
 


### PR DESCRIPTION
# Description

This is a fix for #351 where the rendering fails if the material used for a solid is not of the type `Render.Material`.
In my case the material is of type `Arch.ArchMaterial._ArchMaterial`.
It simply return `False` when the `material.proxy.has_textures()` is undefined.