### PR TITLE
Fix several bugs related to skip meshing

### DIFF
--- a/Render/rdrhandler.py
+++ b/Render/rdrhandler.py
@@ -419,11 +419,12 @@ class RendererHandler:
             debug_flag = PARAMS.GetBool("Debug")
             name = name or view.Source.FullName
             label = label or view.Source.Label
+            fullname = f"'{label}' ('{name}')"
 
             # Skip meshing?
             if self.skip_meshing:
                 # We just need placement, and an empty mesh
-                debug("Object", view.Source.Label, "Skip meshing")
+                debug("Object", fullname, "Skip meshing")
                 mesh = Mesh.Mesh()
                 mesh.Placement = shape.Placement
                 rendermesh = create_rendermesh(
@@ -432,11 +433,11 @@ class RendererHandler:
                     export_directory=self.object_directory,
                     relative_path=True,
                     skip_meshing=self.skip_meshing,
+                    name=fullname,
                 )
                 return rendermesh
 
             # Log
-            fullname = f"'{label}' ('{name}')"
             debug("Object", fullname, "Begin meshing")
             tm0 = time.time()
 

--- a/Render/renderables.py
+++ b/Render/renderables.py
@@ -742,9 +742,7 @@ def _get_rends_from_part(obj, name, material, mesher, **kwargs):
                 subobj, subname, material, mesher, **kwargs
             )
 
-    rends = [
-        _adjust(r, origin, material) for r in rends if r.mesh.count_points
-    ]
+    rends = [_adjust(r, origin, material) for r in rends]
 
     return rends
 

--- a/Render/rendermesh.py
+++ b/Render/rendermesh.py
@@ -415,6 +415,9 @@ class RenderMeshBase:
 
         # Skip meshing?
         if self.skip_meshing:
+            # Check whether file exists
+            if not os.path.isfile(filename):
+                raise SkipMeshingError(filename)
             return res
 
         # Switch to specialized write function
@@ -1638,3 +1641,12 @@ def _check_directory(directory):
         msg = f"Mesh: invalid directory '{directory}'"
         raise ValueError(msg)
     return directory
+
+
+class SkipMeshingError(Exception):
+    """An error occuring while skipping meshing."""
+
+    def __init__(self, filename):
+        self.filename = str(filename)
+        msg = f"'{filename}' does not exist."
+        super().__init__(msg)


### PR DESCRIPTION
1°) App::Part rendering was filtering on mesh.countpoint, which is not convenient for skipping meshes
2°) Missing meshing files were not handled while skipping (can be caused by empty topology at first meshing)