### PR TITLE
Remove No module named 'PySide.QtWidgets' error in earlier versions of FreeCAD

### DIFF
--- a/Render/subcontainer.py
+++ b/Render/subcontainer.py
@@ -51,7 +51,7 @@ import configparser
 import FreeCADGui as Gui
 import FreeCAD as App
 
-from Render.constants import FCDVERSION, PLUGINDIR, PARAMS
+from Render.constants import PLUGINDIR, PARAMS
 from Render.virtualenv import (
     get_venv_python,
     get_venv_pyside_version,
@@ -60,34 +60,21 @@ from Render.virtualenv import (
 from Render.material import make_material
 from Render.lights import ImageLight
 
-if FCDVERSION > (0, 19):
-    from PySide.QtCore import (
-        QProcess,
-        QProcessEnvironment,
-        QObject,
-        Signal,
-        Slot,
-        Qt,
-        QEventLoop,
-    )
-    from PySide.QtWidgets import QWidget
-    from PySide.QtGui import QWindow, QMdiSubWindow, QGuiApplication
-else:
-    from PySide.QtCore import (
-        QProcess,
-        QProcessEnvironment,
-        QObject,
-        Signal,
-        Slot,
-        Qt,
-        QEventLoop,
-    )
-    from PySide.QtGui import (
-        QWidget,
-        QWindow,
-        QMdiSubWindow,
-        QGuiApplication,
-    )
+from PySide.QtCore import (
+    QProcess,
+    QProcessEnvironment,
+    QObject,
+    Signal,
+    Slot,
+    Qt,
+    QEventLoop,
+)
+from PySide.QtGui import (
+    QWidget,
+    QWindow,
+    QMdiSubWindow,
+    QGuiApplication,
+)
 
 
 class ConnectionServer(QObject):


### PR DESCRIPTION
As mentioned [here](https://github.com/FreeCAD/FreeCAD-render/commit/a25677115687697a1f299bf535f0880f2e51a3c5#commitcomment-146072797)  and [this wiki](https://wiki.freecad.org/PySide#:~:text=Normally%2C%20the%20PySide%20module%20provides,of%20FreeCAD%20compiled%20for%20Qt5.) there is an error with PySide Module with PySide.QtWidgets:

> The only unusual aspect is that the PySide2.QtWidgets classes are placed in the PySide.QtGui namespace.