### PR TITLE
Added MacOS specific logic to overcome missing embedded window calls.

### DIFF
--- a/Render/plugins/materialx/downloader/materialx_downloader.py
+++ b/Render/plugins/materialx/downloader/materialx_downloader.py
@@ -235,8 +235,8 @@ class ImporterWorker(QObject):
     """
 
     # Signals
-    finished = Signal(int)
-    _report_progress = Signal(int, int)
+    finished = Signal(object)
+    _report_progress = Signal(object, object)
 
     def __init__(
         self,

--- a/Render/plugins/materialx/downloader/materialx_downloader.py
+++ b/Render/plugins/materialx/downloader/materialx_downloader.py
@@ -235,8 +235,8 @@ class ImporterWorker(QObject):
     """
 
     # Signals
-    finished = Signal(object)
-    _report_progress = Signal(object, object)
+    finished = Signal(int)
+    _report_progress = Signal(int, int)
 
     def __init__(
         self,

--- a/Render/subcontainer.py
+++ b/Render/subcontainer.py
@@ -124,7 +124,7 @@ class PythonSubprocess(QProcess):
     - a communication server to interact with process
     """
 
-    winid_available = Signal(object)
+    winid_available = Signal(int)
     detach_required = Signal()
 
     def __init__(self, python, args, parent=None):
@@ -335,7 +335,7 @@ class PythonSubprocessWindow(QMdiSubWindow):
         self.setWindowTitle("Render")
         mdiarea.addSubWindow(self)
 
-    @Slot(object)
+    @Slot(int)
     def attach_process(self, winid):
         """Attach subprocess to FreeCAD Gui."""
         # Create container and embed process inside

--- a/Render/subcontainer.py
+++ b/Render/subcontainer.py
@@ -341,10 +341,14 @@ class PythonSubprocessWindow(QMdiSubWindow):
         # Create container and embed process inside
         # QWindow.fromWinId is not supported on macOS and QT <6, so open a new window instead.
         if sys.platform == "darwin":
-            print("QWindow.fromWinId not supported on macOS – showing placeholder window.")
+            print(
+                "QWindow.fromWinId not supported on macOS – showing placeholder window."
+            )
             self.container = QWidget()
             layout = QVBoxLayout(self.container)
-            label = QLabel("Renderer running in external window.\nEmbedding not supported on macOS.")
+            label = QLabel(
+                "Renderer running in external window.\nEmbedding not supported on macOS."
+            )
             label.setAlignment(Qt.AlignCenter)
             layout.addWidget(label)
             self.setWidget(self.container)


### PR DESCRIPTION
in #480 it was reported that on MacOS, the Render workbench was crashing when attempting to open the embedded window for downloading materials.

In QT versions below 6.0, there is only buggy or sporadic support for `QWindow.fromWinId`, the method that is used to attach embedded windows to the main window context.  This causes a crash whenever the workbench attempts to create an embedded window.

This PR provides a workaround patch that displays a message on Mac OSX letting users know that the embedding is not support, and then exits.  This allows the window to open as a separate window, rather than an embedded window.

This should fix #480 until Freecad is upgraded to a version that supports QWindow.fromWinId on MacOSX, or else that change is backported to QT 5.xx.